### PR TITLE
make grinder sends content-type

### DIFF
--- a/properties/grinder.properties
+++ b/properties/grinder.properties
@@ -1,7 +1,7 @@
 grinder.script=../scripts/tests.py
 grinder.package_path=/Library/Python/2.7/site-packages
 grinder.runs=1
-grinder.threads=45
+grinder.threads=1
 grinder.useConsole=false
 grinder.consoleHost = 127.0.0.1
 grinder.logDirectory=resources/logs

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -7,7 +7,12 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
 from throttling_group import NullThrottlingGroup
-from HTTPClient import NVPair
+
+try:
+    from HTTPClient import NVPair
+except ImportError:
+    from nvpair import NVPair
+
 
 class AnnotationsIngestThread(AbstractThread):
     def __init__(self, thread_num, agent_num, request, config,

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -7,7 +7,7 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
 from throttling_group import NullThrottlingGroup
-
+from HTTPClient import NVPair
 
 class AnnotationsIngestThread(AbstractThread):
     def __init__(self, thread_num, agent_num, request, config,
@@ -39,5 +39,8 @@ class AnnotationsIngestThread(AbstractThread):
         payload = self.generate_payload(time, metric_id)
 
         self.count_request()
-        result = self.request.POST(self.ingest_url(tenant_id), payload)
+        headers = ( NVPair("Content-Type", "application/json"), )
+        result = self.request.POST(self.ingest_url(tenant_id), payload, headers)
+        if result.getStatusCode() in [400, 500]:
+            logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -46,6 +46,6 @@ class AnnotationsIngestThread(AbstractThread):
         self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(self.ingest_url(tenant_id), payload, headers)
-        if result.getStatusCode() in [400, 500]:
+        if result.getStatusCode() >= 400:
             logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -6,7 +6,12 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
 from throttling_group import NullThrottlingGroup
-from HTTPClient import NVPair
+
+try:
+    from HTTPClient import NVPair
+except ImportError:
+    from nvpair import NVPair
+
 
 RAND_MAX = 982374239
 

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -76,6 +76,6 @@ class IngestThread(AbstractThread):
         self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(self.ingest_url(), payload, headers)
-        if result.getStatusCode() in [400, 415, 500]:
+        if result.getStatusCode() >= 400:
             logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -6,7 +6,7 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
 from throttling_group import NullThrottlingGroup
-
+from HTTPClient import NVPair
 
 RAND_MAX = 982374239
 
@@ -69,5 +69,8 @@ class IngestThread(AbstractThread):
                 tenant_metric_id_values.append(tmv)
         payload = self.generate_payload(time, tenant_metric_id_values)
         self.count_request()
-        result = self.request.POST(self.ingest_url(), payload)
+        headers = ( NVPair("Content-Type", "application/json"), )
+        result = self.request.POST(self.ingest_url(), payload, headers)
+        if result.getStatusCode() in [400, 415, 500]:
+            logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -59,6 +59,6 @@ class EnumIngestThread(AbstractThread):
         self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(self.ingest_url(), payload, headers)
-        if result.getStatusCode() in [400, 415, 500]:
+        if result.getStatusCode() >= 400:
             logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -6,7 +6,12 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread
 from throttling_group import NullThrottlingGroup
-from HTTPClient import NVPair
+
+try:
+    from HTTPClient import NVPair
+except ImportError:
+    from nvpair import NVPair
+
 
 class EnumIngestThread(AbstractThread):
 

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -6,7 +6,7 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread
 from throttling_group import NullThrottlingGroup
-
+from HTTPClient import NVPair
 
 class EnumIngestThread(AbstractThread):
 
@@ -52,5 +52,8 @@ class EnumIngestThread(AbstractThread):
                 tenant_metric_id_values.append(tmv)
         payload = self.generate_payload(time, tenant_metric_id_values)
         self.count_request()
-        result = self.request.POST(self.ingest_url(), payload)
+        headers = ( NVPair("Content-Type", "application/json"), )
+        result = self.request.POST(self.ingest_url(), payload, headers)
+        if result.getStatusCode() in [400, 415, 500]:
+            logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/nvpair.py
+++ b/scripts/nvpair.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+
+def NVPair(*args):
+    return tuple(args)

--- a/scripts/nvpair.py
+++ b/scripts/nvpair.py
@@ -2,4 +2,10 @@
 
 
 def NVPair(*args):
+    """
+    Normally, one would import the NVPair class from Grinder's HTTPClient
+    module. However, when trying to run the tests in an IDE or under python
+    (not jython), HTTPClient is unavailable. In those situations, this function
+    can serve as a simple stand-in.
+    """
     return tuple(args)

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -78,7 +78,7 @@ class MultiPlotQuery(AbstractQuery):
         self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
-        if result.getStatusCode() in [400, 415, 500]:
+        if result.getStatusCode() >= 400:
             logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result
 
@@ -195,6 +195,6 @@ class EnumMultiPlotQuery(AbstractQuery):
         self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
-        if result.getStatusCode() in [400, 415, 500]:
+        if result.getStatusCode() >= 400:
             logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -7,7 +7,11 @@ except ImportError:
 from abstract_thread import AbstractThread, generate_metric_name
 from ingestenum import EnumIngestThread
 from throttling_group import NullThrottlingGroup
-from HTTPClient import NVPair
+
+try:
+    from HTTPClient import NVPair
+except ImportError:
+    from nvpair import NVPair
 
 
 class AbstractQuery(AbstractThread):

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -7,6 +7,7 @@ except ImportError:
 from abstract_thread import AbstractThread, generate_metric_name
 from ingestenum import EnumIngestThread
 from throttling_group import NullThrottlingGroup
+from HTTPClient import NVPair
 
 
 class AbstractQuery(AbstractThread):
@@ -71,7 +72,10 @@ class MultiPlotQuery(AbstractQuery):
             tenant_id, frm,
             to, resolution)
         self.count_request()
-        result = self.request.POST(url, payload)
+        headers = ( NVPair("Content-Type", "application/json"), )
+        result = self.request.POST(url, payload, headers)
+        if result.getStatusCode() in [400, 415, 500]:
+            logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result
 
 
@@ -185,5 +189,8 @@ class EnumMultiPlotQuery(AbstractQuery):
             tenant_id, frm,
             to, resolution)
         self.count_request()
-        result = self.request.POST(url, payload)
+        headers = ( NVPair("Content-Type", "application/json"), )
+        result = self.request.POST(url, payload, headers)
+        if result.getStatusCode() in [400, 415, 500]:
+            logger("Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -49,7 +49,7 @@ class MockReq():
         self.post_payload = None
         self.get_url = None
 
-    def POST(self, url, payload, headers):
+    def POST(self, url, payload, headers=None):
         global post_url, post_payload
         post_url = url
         post_payload = payload
@@ -57,7 +57,7 @@ class MockReq():
         self.post_payload = payload
         return MockResponse(self)
 
-    def GET(self, url, payload, headers):
+    def GET(self, url, payload=None, headers=None):
         global get_url
         get_url = url
         self.get_url = url

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -513,8 +513,10 @@ class MakeAnnotationsIngestRequestsTest(TestCaseBase):
             "what": "annotation org.example.metric.%s" % metric_id,
             "when": 1000, "tags": "tag", "data": "data"}
 
-        url, payload = thread.make_request(pp, 1000, tenant_id,
-                                           metric_id)
+        response = thread.make_request(pp, 1000, tenant_id, metric_id)
+        url = response.request.post_url
+        payload = response.request.post_payload
+
         # confirm request generates proper URL and payload
         self.assertEqual(
             url,
@@ -576,8 +578,10 @@ class MakeIngestRequestsTest(TestCaseBase):
             [2, 0, 0],
             [2, 1, 0]
         ]
-        url, payload = thread.make_request(pp, 1000,
-                                           tenant_metric_id_values)
+        response = thread.make_request(pp, 1000, tenant_metric_id_values)
+        url = response.request.post_url
+        payload = response.request.post_payload
+
         # confirm request generates proper URL and payload
         self.assertEqual(
             url,
@@ -649,9 +653,12 @@ class MakeIngestEnumRequestsTest(TestCaseBase):
             }
         ]
 
-        url, payload = thread.make_request(
+        response = thread.make_request(
             pp, 1000,
             tenant_metric_id_values=[[2, 0, 'e_g_0_0'], [2, 1, 'e_g_1_0']])
+        url = response.request.post_url
+        payload = response.request.post_payload
+
         # confirm request generates proper URL and payload
         self.assertEqual(url,
                          'http://metrics-ingest.example.org/v2.0/tenantId/' +
@@ -668,21 +675,21 @@ class MakeQueryRequestsTest(TestCaseBase):
     def test_query_make_SinglePlotQuery_request(self):
         req = requests_by_type[query.SinglePlotQuery]
         qq = query.SinglePlotQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 0, 'org.example.metric.metric123')
+        response = qq.make_request(None, 1000, 0, 'org.example.metric.metric123')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/0/views/" +
                          "org.example.metric.metric123?from=-86399000&" +
                          "to=1000&resolution=FULL")
-        self.assertEquals(req.get_url, result)
+        self.assertIs(req, response.request)
 
     def test_query_make_SearchQuery_request(self):
         req = requests_by_type[query.SearchQuery]
         qq = query.SearchQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 10, 'org.example.metric.*')
+        response = qq.make_request(None, 1000, 10, 'org.example.metric.*')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/10/metrics/search?" +
                          "query=org.example.metric.*")
-        self.assertEquals(req.get_url, result)
+        self.assertIs(req, response.request)
 
     def test_query_make_MultiPlotQuery_request(self):
         req = requests_by_type[query.MultiPlotQuery]
@@ -699,43 +706,42 @@ class MakeQueryRequestsTest(TestCaseBase):
             "org.example.metric.8",
             "org.example.metric.9"
         ])
-        result = qq.make_request(None, 1000, 20,
-                                 payload_sent)
+        response = qq.make_request(None, 1000, 20, payload_sent)
         self.assertEqual(req.post_url,
                          "http://metrics.example.org/v2.0/20/views?" +
                          "from=-86399000&to=1000&resolution=FULL")
         self.assertEqual(req.post_payload, payload_sent)
-        self.assertEquals((req.post_url, req.post_payload), result)
+        self.assertIs(req, response.request)
 
     def test_query_make_AnnotationsQuery_request(self):
         req = requests_by_type[query.AnnotationsQuery]
         qq = query.AnnotationsQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 30)
+        response = qq.make_request(None, 1000, 30)
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/30/events/" +
                          "getEvents?from=-86399000&until=1000")
-        self.assertEquals(req.get_url, result)
+        self.assertIs(req, response.request)
 
     def test_query_make_EnumSearchQuery_request(self):
         req = requests_by_type[query.EnumSearchQuery]
         qq = query.EnumSearchQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 40)
+        response = qq.make_request(None, 1000, 40)
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/40/metrics/search?" +
                          "query=enum_grinder_org.example.metric.*&" +
                          "include_enum_values=true")
-        self.assertEquals(req.get_url, result)
+        self.assertIs(req, response.request)
 
     def test_query_make_EnumSinglePlotQuery_request(self):
         req = requests_by_type[query.EnumSinglePlotQuery]
         qq = query.EnumSinglePlotQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 50,
+        response = qq.make_request(None, 1000, 50,
                                  'enum_grinder_org.example.metric.metric456')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/50/views/" +
                          "enum_grinder_org.example.metric.metric456?" +
                          "from=-86399000&to=1000&resolution=FULL")
-        self.assertEquals(req.get_url, result)
+        self.assertIs(req, response.request)
 
     def test_query_make_EnumMultiPlotQuery_request(self):
         req = requests_by_type[query.EnumMultiPlotQuery]
@@ -746,13 +752,12 @@ class MakeQueryRequestsTest(TestCaseBase):
             "enum_grinder_org.example.metric.2",
             "enum_grinder_org.example.metric.3"
         ])
-        result = qq.make_request(None, 1000, 4,
-                                 payload_sent)
+        response = qq.make_request(None, 1000, 4, payload_sent)
         self.assertEqual(req.post_url,
                          "http://metrics.example.org/v2.0/4/views?" +
                          "from=-86399000&to=1000&resolution=FULL")
         self.assertEqual(req.post_payload, payload_sent)
-        self.assertEquals((req.post_url, req.post_payload), result)
+        self.assertIs(req, response.request)
 
 
 class ThrottlingGroupTest(unittest.TestCase):

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -55,13 +55,13 @@ class MockReq():
         post_payload = payload
         self.post_url = url
         self.post_payload = payload
-        return url, payload
+        return MockResponse(self)
 
     def GET(self, url, payload, headers):
         global get_url
         get_url = url
         self.get_url = url
-        return url
+        return MockResponse(self)
 
 requests_by_type = {
     ingest.IngestThread:                        MockReq(),

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -34,6 +34,15 @@ def mock_sleep(cls, x):
     sleep_time = x
 
 
+class MockResponse(object):
+    def __init__(self, request, status_code=200):
+        self.request = request
+        self.status_code = status_code
+
+    def getStatusCode(self):
+        return self.status_code
+
+
 class MockReq():
     def __init__(self):
         self.post_url = None

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -40,7 +40,7 @@ class MockReq():
         self.post_payload = None
         self.get_url = None
 
-    def POST(self, url, payload):
+    def POST(self, url, payload, headers):
         global post_url, post_payload
         post_url = url
         post_payload = payload
@@ -48,7 +48,7 @@ class MockReq():
         self.post_payload = payload
         return url, payload
 
-    def GET(self, url):
+    def GET(self, url, payload, headers):
         global get_url
         get_url = url
         self.get_url = url


### PR DESCRIPTION
To adapt to changes in blueflood REST API. It now requires Content-Type header to be set correctly. Grinder defaults to sending ```Content-Type: application/octet-stream``` which is rejected by Blueflood now.