### PR TITLE
Throttling request

### DIFF
--- a/scripts/abstract_thread.py
+++ b/scripts/abstract_thread.py
@@ -52,20 +52,15 @@ class AbstractThread(object):
     def make_request(self, logger, time):
         raise Exception("Can't create abstract thread")
 
-    def __init__(self, thread_num, agent_num, request, config,
-                 tgroup=NullThrottlingGroup()):
+    def __init__(self, thread_num, agent_num, request, config):
 
         self.thread_num = thread_num
         self.agent_num = agent_num
         self.request = request
-        self.tgroup = tgroup
 
         self.config = default_config.copy()
         if config:
             self.config.update(config)
-
-    def count_request(self):
-        self.tgroup.count_request()
 
     @classmethod
     def time(cls):

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -15,8 +15,6 @@ except ImportError:
 
 
 class AnnotationsIngestThread(AbstractThread):
-    def __init__(self, thread_num, agent_num, request, config):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config)
 
     def generate_annotation(self, time, metric_id):
         metric_name = generate_metric_name(metric_id, self.config)

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -15,10 +15,8 @@ except ImportError:
 
 
 class AnnotationsIngestThread(AbstractThread):
-    def __init__(self, thread_num, agent_num, request, config,
-                 tgroup=NullThrottlingGroup()):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config,
-                                tgroup)
+    def __init__(self, thread_num, agent_num, request, config):
+        AbstractThread.__init__(self, thread_num, agent_num, request, config)
 
     def generate_annotation(self, time, metric_id):
         metric_name = generate_metric_name(metric_id, self.config)
@@ -43,7 +41,6 @@ class AnnotationsIngestThread(AbstractThread):
                 1, self.config['annotations_per_tenant'])
         payload = self.generate_payload(time, metric_id)
 
-        self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(self.ingest_url(tenant_id), payload, headers)
         if result.getStatusCode() >= 400:

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -16,6 +16,7 @@ from query import EnumMultiPlotQuery
 from config import clean_configs
 import abstract_thread
 from throttling_group import ThrottlingGroup
+from throttling_request import ThrottlingRequest
 
 # ENTRY POINT into the Grinder
 
@@ -48,10 +49,13 @@ for k, v in config.iteritems():
         throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
-def create_request_obj(test_num, test_name):
+def create_request_obj(test_num, test_name, tgroup_name=None):
     test = Test(test_num, test_name)
     request = HTTPRequest()
     test.record(request)
+    if tgroup_name:
+        tgroup = throttling_groups[tgroup_name]
+        request = ThrottlingRequest(tgroup, request)
     return request
 
 requests_by_type = {

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -59,17 +59,40 @@ def create_request_obj(test_num, test_name, tgroup_name=None):
     return request
 
 requests_by_type = {
-    IngestThread: create_request_obj(1, "Ingest test"),
+    IngestThread:
+        create_request_obj(
+            1,
+            "Ingest test",
+            config.get('ingest_throttling_group', None)),
     EnumIngestThread: create_request_obj(7, "Enum Ingest test"),
     AnnotationsIngestThread:
-        create_request_obj(2, "Annotations Ingest test"),
-    SinglePlotQuery: create_request_obj(3, "SinglePlotQuery"),
-    MultiPlotQuery: create_request_obj(4, "MultiPlotQuery"),
-    SearchQuery: create_request_obj(5, "SearchQuery"),
+        create_request_obj(
+            2,
+            "Annotations Ingest test",
+            config.get('annotations_throttling_group', None)),
+    SinglePlotQuery:
+        create_request_obj(
+            3,
+            "SinglePlotQuery",
+            config.get('singleplot_query_throttling_group', None)),
+    MultiPlotQuery:
+        create_request_obj(
+            4,
+            "MultiPlotQuery",
+            config.get('multiplot_query_throttling_group', None)),
+    SearchQuery:
+        create_request_obj(
+            5,
+            "SearchQuery",
+            config.get('search_query_throttling_group', None)),
     EnumSearchQuery: create_request_obj(8, "EnumSearchQuery"),
     EnumSinglePlotQuery: create_request_obj(9, "EnumSinglePlotQuery"),
     EnumMultiPlotQuery: create_request_obj(10, "EnumMultiPlotQuery"),
-    AnnotationsQuery: create_request_obj(6, "AnnotationsQuery"),
+    AnnotationsQuery:
+        create_request_obj(
+            6,
+            "AnnotationsQuery",
+            config.get('annotations_query_throttling_group', None)),
 }
 
 thread_manager = tm.ThreadManager(config, requests_by_type)

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -35,12 +35,24 @@ from throttling_group import ThrottlingGroup
 #
 
 
+config = abstract_thread.default_config.copy()
+config.update(clean_configs(py_java.get_config_from_grinder(grinder)))
+
+throttling_groups = {}
+for k, v in config.iteritems():
+    m = re.match(
+        '(grinder\.bf\.)?throttling_group\.(\w+)\.max_requests_per_minute',
+        str(k))
+    if m:
+        name = m.groups()[-1]
+        throttling_groups[name] = ThrottlingGroup(name, int(v))
+
+
 def create_request_obj(test_num, test_name):
     test = Test(test_num, test_name)
     request = HTTPRequest()
     test.record(request)
     return request
-
 
 requests_by_type = {
     IngestThread: create_request_obj(1, "Ingest test"),
@@ -56,18 +68,7 @@ requests_by_type = {
     AnnotationsQuery: create_request_obj(6, "AnnotationsQuery"),
 }
 
-config = abstract_thread.default_config.copy()
-config.update(clean_configs(py_java.get_config_from_grinder(grinder)))
 thread_manager = tm.ThreadManager(config, requests_by_type)
-
-throttling_groups = {}
-for k, v in config.iteritems():
-    m = re.match(
-        '(grinder\.bf\.)?throttling_group\.(\w+)\.max_requests_per_minute',
-        str(k))
-    if m:
-        name = m.groups()[-1]
-        throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
 class TestRunner:

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -27,10 +27,8 @@ class IngestThread(AbstractThread):
         5: 'decades'
     }
 
-    def __init__(self, thread_num, agent_num, request, config,
-                 tgroup=NullThrottlingGroup()):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config,
-                                tgroup)
+    def __init__(self, thread_num, agent_num, request, config):
+        AbstractThread.__init__(self, thread_num, agent_num, request, config)
 
     def generate_unit(self, tenant_id):
         unit_number = tenant_id % 6
@@ -73,7 +71,6 @@ class IngestThread(AbstractThread):
                 tmv = [tenant_id, metric_id, value]
                 tenant_metric_id_values.append(tmv)
         payload = self.generate_payload(time, tenant_metric_id_values)
-        self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(self.ingest_url(), payload, headers)
         if result.getStatusCode() >= 400:

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -27,9 +27,6 @@ class IngestThread(AbstractThread):
         5: 'decades'
     }
 
-    def __init__(self, thread_num, agent_num, request, config):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config)
-
     def generate_unit(self, tenant_id):
         unit_number = tenant_id % 6
         return self.units_map[unit_number]

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -20,9 +20,6 @@ class EnumIngestThread(AbstractThread):
     def generate_enum_metric_name(metric_id, config):
         return "enum_grinder_" + config['name_fmt'] % metric_id
 
-    def __init__(self, thread_num, agent_num, request, config):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config)
-
     def generate_enum_suffix(self):
         return "_" + str(random.randint(0, self.config['enum_num_values']))
 

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -20,10 +20,8 @@ class EnumIngestThread(AbstractThread):
     def generate_enum_metric_name(metric_id, config):
         return "enum_grinder_" + config['name_fmt'] % metric_id
 
-    def __init__(self, thread_num, agent_num, request, config,
-                 tgroup=NullThrottlingGroup()):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config,
-                                tgroup)
+    def __init__(self, thread_num, agent_num, request, config):
+        AbstractThread.__init__(self, thread_num, agent_num, request, config)
 
     def generate_enum_suffix(self):
         return "_" + str(random.randint(0, self.config['enum_num_values']))
@@ -56,7 +54,6 @@ class EnumIngestThread(AbstractThread):
                 tmv = [tenant_id, metric_id, value]
                 tenant_metric_id_values.append(tmv)
         payload = self.generate_payload(time, tenant_metric_id_values)
-        self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(self.ingest_url(), payload, headers)
         if result.getStatusCode() >= 400:

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -19,10 +19,9 @@ class AbstractQuery(AbstractThread):
 
     query_interval_name = None
 
-    def __init__(self, thread_num, agent_number, request, config,
-                 tgroup=NullThrottlingGroup()):
+    def __init__(self, thread_num, agent_number, request, config):
         AbstractThread.__init__(self, thread_num, agent_number, request,
-                                config, tgroup)
+                                config)
         self.thread_num = thread_num
         self.config = config
         self.request = request
@@ -46,7 +45,6 @@ class SinglePlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, metric_name, frm,
             to, resolution)
-        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -75,7 +73,6 @@ class MultiPlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, frm,
             to, resolution)
-        self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
         if result.getStatusCode() >= 400:
@@ -101,7 +98,6 @@ class SearchQuery(AbstractQuery):
         url = "%s/v2.0/%d/metrics/search?query=%s" % (
             self.config['query_url'],
             tenant_id, metric_regex)
-        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -117,7 +113,6 @@ class AnnotationsQuery(AbstractQuery):
         frm = time - self.one_day
         url = "%s/v2.0/%d/events/getEvents?from=%d&until=%d" % (
             self.config['query_url'], tenant_id, frm, to)
-        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -140,7 +135,6 @@ class EnumSearchQuery(AbstractQuery):
         url = "%s/v2.0/%d/metrics/search?query=%s&include_enum_values=true" % (
             self.config['query_url'],
             tenant_id, metric_regex)
-        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -163,7 +157,6 @@ class EnumSinglePlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, metric_name, frm,
             to, resolution)
-        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -192,7 +185,6 @@ class EnumMultiPlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, frm,
             to, resolution)
-        self.count_request()
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
         if result.getStatusCode() >= 400:

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -15,6 +15,7 @@ import abstract_thread
 import thread_manager as tm
 from config import clean_configs
 from throttling_group import ThrottlingGroup
+from throttling_request import ThrottlingRequest
 
 try:
     from com.xhaus.jyson import JysonCodec as json
@@ -878,14 +879,15 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
             sleeps.append(arg)
 
         tgroup = ThrottlingGroup('test', 6, time_source, sleep_source)
+        treq = ThrottlingRequest(tgroup, MockReq())
 
-        th1 = ingest.IngestThread(0, 0, MockReq(), self.test_config, tgroup)
+        th1 = ingest.IngestThread(0, 0, treq, self.test_config)
         th2 = annotationsingest.AnnotationsIngestThread(
-            1, 0, MockReq(), self.test_config, tgroup)
-        th3 = query.SinglePlotQuery(2, 0, MockReq(), self.test_config, tgroup)
-        th4 = query.MultiPlotQuery(3, 0, MockReq(), self.test_config, tgroup)
-        th5 = query.SearchQuery(4, 0, MockReq(), self.test_config, tgroup)
-        th6 = query.AnnotationsQuery(5, 0, MockReq(), self.test_config, tgroup)
+            1, 0, treq, self.test_config)
+        th3 = query.SinglePlotQuery(2, 0, treq, self.test_config)
+        th4 = query.MultiPlotQuery(3, 0, treq, self.test_config)
+        th5 = query.SearchQuery(4, 0, treq, self.test_config)
+        th6 = query.AnnotationsQuery(5, 0, treq, self.test_config)
 
         # when
         th1.make_request(pp, 1000)

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -92,6 +92,6 @@ class ThreadManager(object):
             tgroup = None
             if tgname and trgoups and tgname in tgroups:
                 tgroup = tgroups[tgname]
-            return thread_type(thread_num, agent_num, req, self.config, tgroup)
+            return thread_type(thread_num, agent_num, req, self.config)
         else:
             raise TypeError("Unknown thread type: %s" % str(thread_type))

--- a/scripts/throttling_request.py
+++ b/scripts/throttling_request.py
@@ -11,28 +11,28 @@ class ThrottlingRequest(object):
 
     def GET(self, *args, **kwargs):
         self.count_request()
-        self.request.GET(*args, **kwargs)
+        return self.request.GET(*args, **kwargs)
 
     def HEAD(self, *args, **kwargs):
         self.count_request()
-        self.request.HEAD(*args, **kwargs)
+        return self.request.HEAD(*args, **kwargs)
 
     def POST(self, *args, **kwargs):
         self.count_request()
-        self.request.POST(*args, **kwargs)
+        return self.request.POST(*args, **kwargs)
 
     def PUT(self, *args, **kwargs):
         self.count_request()
-        self.request.PUT(*args, **kwargs)
+        return self.request.PUT(*args, **kwargs)
 
     def DELETE(self, *args, **kwargs):
         self.count_request()
-        self.request.DELETE(*args, **kwargs)
+        return self.request.DELETE(*args, **kwargs)
 
     def OPTIONS(self, *args, **kwargs):
         self.count_request()
-        self.request.OPTIONS(*args, **kwargs)
+        return self.request.OPTIONS(*args, **kwargs)
 
     def TRACE(self, *args, **kwargs):
         self.count_request()
-        self.request.TRACE(*args, **kwargs)
+        return self.request.TRACE(*args, **kwargs)

--- a/scripts/throttling_request.py
+++ b/scripts/throttling_request.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+
+class ThrottlingRequest(object):
+    def __init__(self, tgroup, request):
+        self.tgroup = tgroup
+        self.request = request
+
+    def count_request(self):
+        self.tgroup.count_request()
+
+    def GET(self, *args, **kwargs):
+        self.count_request()
+        self.request.GET(*args, **kwargs)
+
+    def HEAD(self, *args, **kwargs):
+        self.count_request()
+        self.request.HEAD(*args, **kwargs)
+
+    def POST(self, *args, **kwargs):
+        self.count_request()
+        self.request.POST(*args, **kwargs)
+
+    def PUT(self, *args, **kwargs):
+        self.count_request()
+        self.request.PUT(*args, **kwargs)
+
+    def DELETE(self, *args, **kwargs):
+        self.count_request()
+        self.request.DELETE(*args, **kwargs)
+
+    def OPTIONS(self, *args, **kwargs):
+        self.count_request()
+        self.request.OPTIONS(*args, **kwargs)
+
+    def TRACE(self, *args, **kwargs):
+        self.count_request()
+        self.request.TRACE(*args, **kwargs)


### PR DESCRIPTION
This PR refactors the code a little. While trying to run the test scripts, I had been getting the python equivalent of a null pointer error. It turned out that a certain field wasn't getting initialized properly. This should fix that.

It wraps the call to GET, POST, etc, so that the throttling mechanism can be activated automatically, instead of forcing the `AbstractThread` subclasses to do it themselves. Much more OO this way.