### PR TITLE
Record non 200s as errors

### DIFF
--- a/run-unit-tests-with-coverage.sh
+++ b/run-unit-tests-with-coverage.sh
@@ -2,6 +2,6 @@
 
 topsrc=`dirname $0`  # this gives you the directory where this script is located
 cd $topsrc
-coverage run --source=abstract_thread,annotationsingest,ingest,ingestenum,query,thread_manager,config,throttling_group scripts/tests.py
+coverage run --source=abstract_thread,annotationsingest,authenticating_request,config,connector,exception_handling_request,get_user,grinder,grinder_connector,http_failure_exception,ingest,ingestenum,nvpair,py_java,query,requests_connector,response_checking_request,thread_manager,throttling_group,throttling_request,user scripts/tests.py
 coverage html
 

--- a/scripts/exception_handling_request.py
+++ b/scripts/exception_handling_request.py
@@ -5,9 +5,10 @@ from http_failure_exception import HttpFailureException
 class ExceptionHandlingRequest():
 
     """This class catches exceptions thrown by the wrapped request object,
-     namely a ResponseCheckingRequest instance. That way, if there is an HTTP
-     error, it gets counted in the grinder statistics, but the exception
-     stacktrace doesn't clutter up the grinder logs."""
+     namely a `response_checking_request.ResponseCheckingRequest` instance.
+     That way, if there is an HTTP error, it gets counted in the grinder
+     statistics, but the exception stacktrace doesn't clutter up the grinder
+     logs."""
 
     def __init__(self, request):
         self.request = request

--- a/scripts/exception_handling_request.py
+++ b/scripts/exception_handling_request.py
@@ -1,4 +1,6 @@
 
+from http_failure_exception import HttpFailureException
+
 
 class ExceptionHandlingRequest():
 
@@ -13,8 +15,8 @@ class ExceptionHandlingRequest():
     def wrap(self, callee):
         try:
             return callee()
-        except:
-            return None
+        except HttpFailureException as e:
+            return e.response
 
     def GET(self, *args, **kwargs):
         return self.wrap(lambda:self.request.GET(*args, **kwargs))

--- a/scripts/exception_handling_request.py
+++ b/scripts/exception_handling_request.py
@@ -1,0 +1,38 @@
+
+
+class ExceptionHandlingRequest():
+
+    """This class catches exceptions thrown by the wrapped request object,
+     namely a ResponseCheckingRequest instance. That way, if there is an HTTP
+     error, it gets counted in the grinder statistics, but the exception
+     stacktrace doesn't clutter up the grinder logs."""
+
+    def __init__(self, request):
+        self.request = request
+
+    def wrap(self, callee):
+        try:
+            return callee()
+        except:
+            return None
+
+    def GET(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.GET(*args, **kwargs))
+
+    def HEAD(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.HEAD(*args, **kwargs))
+
+    def POST(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.POST(*args, **kwargs))
+
+    def PUT(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.PUT(*args, **kwargs))
+
+    def DELETE(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.DELETE(*args, **kwargs))
+
+    def OPTIONS(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.OPTIONS(*args, **kwargs))
+
+    def TRACE(self, *args, **kwargs):
+        return self.wrap(lambda:self.request.TRACE(*args, **kwargs))

--- a/scripts/exception_handling_request.py
+++ b/scripts/exception_handling_request.py
@@ -15,7 +15,7 @@ class ExceptionHandlingRequest():
     def wrap(self, callee):
         try:
             return callee()
-        except HttpFailureException as e:
+        except HttpFailureException, e:
             return e.response
 
     def GET(self, *args, **kwargs):

--- a/scripts/exception_handling_request.py
+++ b/scripts/exception_handling_request.py
@@ -19,22 +19,22 @@ class ExceptionHandlingRequest():
             return e.response
 
     def GET(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.GET(*args, **kwargs))
+        return self.wrap(lambda: self.request.GET(*args, **kwargs))
 
     def HEAD(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.HEAD(*args, **kwargs))
+        return self.wrap(lambda: self.request.HEAD(*args, **kwargs))
 
     def POST(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.POST(*args, **kwargs))
+        return self.wrap(lambda: self.request.POST(*args, **kwargs))
 
     def PUT(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.PUT(*args, **kwargs))
+        return self.wrap(lambda: self.request.PUT(*args, **kwargs))
 
     def DELETE(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.DELETE(*args, **kwargs))
+        return self.wrap(lambda: self.request.DELETE(*args, **kwargs))
 
     def OPTIONS(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.OPTIONS(*args, **kwargs))
+        return self.wrap(lambda: self.request.OPTIONS(*args, **kwargs))
 
     def TRACE(self, *args, **kwargs):
-        return self.wrap(lambda:self.request.TRACE(*args, **kwargs))
+        return self.wrap(lambda: self.request.TRACE(*args, **kwargs))

--- a/scripts/get_user.py
+++ b/scripts/get_user.py
@@ -15,6 +15,41 @@ import py_java
 
 
 def get_user(config, grinder):
+    """Load user credentials from the provided config.
+
+    The algorithm proceeds as follows:
+
+    First, the config is checked for the `auth_url`, `auth_username`, and
+    `auth_api_key` properties. If those are provided, then a `user.User` object
+    is constructed and returned.
+
+    If any of those properties is not provided in the main configuration file,
+    then the `auth_properties_path` property is checked. If that is not
+    provided, processing stops and `None` is returned. Otherwise, the
+    `auth_properties_path` property is interpreted as the relative path to a
+    second properties file.
+
+    Similar to the above, the second properties file will be checked for the
+    `auth_url`, `auth_username`, and `auth_api_key` properties. If those are
+    provided, then a `user.User` object is constructed and returned. If any of those
+    properties is not provided, then `None` is returned.
+
+    No attempt is made to authenticate the user based on the provided
+    properties. Authentication will occur lazily the calling code tries to
+    access the `User`'s token or tenant data. If the credentials are incorrect,
+    an error will occur then, rather than in this function.
+
+    Any exceptions (e.g. `IOError("File not found")` ) are propagated to the
+    caller.
+
+    :param config: the test configuration loaded from the .properties file(s)
+    :param grinder: the ScriptContext provided by The Grinder, used to resolve
+        file paths
+
+    :return: a user.User object for the configured user credentials, or None if
+        any credential properties weren't provided in the config.
+    :rtype: user.User
+    """
     auth_url = config.get('auth_url', None)
     auth_username = config.get('auth_username', None)
     auth_api_key = config.get('auth_api_key', None)

--- a/scripts/get_user.py
+++ b/scripts/get_user.py
@@ -31,8 +31,8 @@ def get_user(config, grinder):
 
     Similar to the above, the second properties file will be checked for the
     `auth_url`, `auth_username`, and `auth_api_key` properties. If those are
-    provided, then a `user.User` object is constructed and returned. If any of those
-    properties is not provided, then `None` is returned.
+    provided, then a `user.User` object is constructed and returned. If any of
+    those properties is not provided, then `None` is returned.
 
     No attempt is made to authenticate the user based on the provided
     properties. Authentication will occur lazily the calling code tries to
@@ -74,14 +74,16 @@ def get_user(config, grinder):
     user_creds_relative_path = config.get('auth_properties_path', None)
     if user_creds_relative_path:
         user_creds_relative = java.io.File(user_creds_relative_path)
-        user_creds_file = grinder.getProperties().resolveRelativeFile(user_creds_relative)
+        user_creds_file = grinder.getProperties().resolveRelativeFile(
+            user_creds_relative)
         stream = java.io.FileInputStream(user_creds_file)
         if encryptor:
             user_creds_props = EncryptableProperties(encryptor)
         else:
             user_creds_props = java.util.Properties()
         user_creds_props.load(stream)
-        user_creds_dict = clean_configs(py_java.dict_from_properties(user_creds_props))
+        user_creds_dict = clean_configs(
+            py_java.dict_from_properties(user_creds_props))
         auth_url = user_creds_dict.get('auth_url', None)
         auth_username = user_creds_dict.get('auth_username', None)
         auth_api_key = user_creds_dict.get('auth_api_key', None)

--- a/scripts/get_user.py
+++ b/scripts/get_user.py
@@ -1,0 +1,55 @@
+
+import os.path
+
+import java.lang.System
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
+
+from org.jasypt.properties import EncryptableProperties
+from org.jasypt.encryption.pbe import StandardPBEStringEncryptor
+
+from user import User
+from config import clean_configs
+import py_java
+
+
+def get_user(config, grinder):
+    auth_url = config.get('auth_url', None)
+    auth_username = config.get('auth_username', None)
+    auth_api_key = config.get('auth_api_key', None)
+    if auth_url and auth_username and auth_api_key:
+        return User(auth_url, auth_username, auth_api_key)
+
+    auth_properties_encr_key_file = config.get('auth_properties_encr_key_file',
+                                               None)
+    encryptor = None
+    if auth_properties_encr_key_file:
+        auth_properties_encr_key_file = os.path.expanduser(
+            auth_properties_encr_key_file)
+        stream = java.io.FileInputStream(auth_properties_encr_key_file)
+        auth_props_encr_key_props = java.util.Properties()
+        auth_props_encr_key_props.load(stream)
+        auth_props_encr_key_dict = py_java.dict_from_properties(
+            auth_props_encr_key_props)
+        auth_props_encr_key = auth_props_encr_key_dict.get('password', None)
+        encryptor = StandardPBEStringEncryptor()
+        encryptor.setPassword(auth_props_encr_key)
+
+    user_creds_relative_path = config.get('auth_properties_path', None)
+    if user_creds_relative_path:
+        user_creds_relative = java.io.File(user_creds_relative_path)
+        user_creds_file = grinder.getProperties().resolveRelativeFile(user_creds_relative)
+        stream = java.io.FileInputStream(user_creds_file)
+        if encryptor:
+            user_creds_props = EncryptableProperties(encryptor)
+        else:
+            user_creds_props = java.util.Properties()
+        user_creds_props.load(stream)
+        user_creds_dict = clean_configs(py_java.dict_from_properties(user_creds_props))
+        auth_url = user_creds_dict.get('auth_url', None)
+        auth_username = user_creds_dict.get('auth_username', None)
+        auth_api_key = user_creds_dict.get('auth_api_key', None)
+        if auth_url and auth_username and auth_api_key:
+            return User(auth_url, auth_username, auth_api_key)
+    return None

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -1,19 +1,9 @@
 
 import re
-import sys
-import os.path
-
-import java.lang.System
-import java.io.File
-import java.io.FileInputStream
-import java.util.Properties
 
 from net.grinder.script.Grinder import grinder
 from net.grinder.script import Test
 from net.grinder.plugin.http import HTTPRequest
-
-from org.jasypt.properties import EncryptableProperties
-from org.jasypt.encryption.pbe import StandardPBEStringEncryptor
 
 import thread_manager as tm
 import py_java
@@ -28,7 +18,7 @@ import abstract_thread
 from throttling_group import ThrottlingGroup
 from throttling_request import ThrottlingRequest
 from authenticating_request import AuthenticatingRequest
-from user import User
+from get_user import get_user
 
 # ENTRY POINT into the Grinder
 
@@ -78,45 +68,9 @@ user = None
 # TODO: re-work how user credentials are retrieved into something like a plugin
 # TODO: system, so that it's more robust, easier to use, and less verbose
 
-auth_url = config.get('auth_url', None)
-auth_username = config.get('auth_username', None)
-auth_api_key = config.get('auth_api_key', None)
-if auth_url and auth_username and auth_api_key:
-    user = User(auth_url, auth_username, auth_api_key)
 
-if user is None:
-    auth_properties_encr_key_file = config.get('auth_properties_encr_key_file',
-                                               None)
-    encryptor = None
-    if auth_properties_encr_key_file:
-        auth_properties_encr_key_file = os.path.expanduser(
-            auth_properties_encr_key_file)
-        stream = java.io.FileInputStream(auth_properties_encr_key_file)
-        auth_props_encr_key_props = java.util.Properties()
-        auth_props_encr_key_props.load(stream)
-        auth_props_encr_key_dict = py_java.dict_from_properties(
-            auth_props_encr_key_props)
-        auth_props_encr_key = auth_props_encr_key_dict.get('password', None)
-        encryptor = StandardPBEStringEncryptor()
-        encryptor.setPassword(auth_props_encr_key)
 
-    user_creds_relative_path = config.get('auth_properties_path', None)
-    if user_creds_relative_path:
-        user_creds_relative = java.io.File(user_creds_relative_path)
-        user_creds_file = grinder.getProperties().resolveRelativeFile(user_creds_relative)
-        stream = java.io.FileInputStream(user_creds_file)
-        if encryptor:
-            user_creds_props = EncryptableProperties(encryptor)
-        else:
-            user_creds_props = java.util.Properties()
-        user_creds_props.load(stream)
-        user_creds_dict = clean_configs(py_java.dict_from_properties(user_creds_props))
-        auth_url = user_creds_dict.get('auth_url', None)
-        auth_username = user_creds_dict.get('auth_username', None)
-        auth_api_key = user_creds_dict.get('auth_api_key', None)
-        if auth_url and auth_username and auth_api_key:
-            user = User(auth_url, auth_username, auth_api_key)
-
+user = get_user(config, grinder)
 
 requests_by_type = {
     IngestThread:

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -18,6 +18,7 @@ import abstract_thread
 from throttling_group import ThrottlingGroup
 from throttling_request import ThrottlingRequest
 from authenticating_request import AuthenticatingRequest
+from response_checking_request import ResponseCheckingRequest
 from get_user import get_user
 
 # ENTRY POINT into the Grinder
@@ -55,6 +56,7 @@ def create_request_obj(test_num, test_name, tgroup_name=None,
                        auth_user=None):
     test = Test(test_num, test_name)
     request = HTTPRequest()
+    request = ResponseCheckingRequest(request)
     test.record(request)
     if auth_user:
         request = AuthenticatingRequest(request, auth_user)

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -58,8 +58,8 @@ def create_request_obj(test_num, test_name, tgroup_name=None,
     test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)
-    request = ExceptionHandlingRequest(request)
     test.record(request)
+    request = ExceptionHandlingRequest(request)
     if auth_user:
         request = AuthenticatingRequest(request, auth_user)
     if tgroup_name:

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -19,6 +19,7 @@ from throttling_group import ThrottlingGroup
 from throttling_request import ThrottlingRequest
 from authenticating_request import AuthenticatingRequest
 from response_checking_request import ResponseCheckingRequest
+from exception_handling_request import ExceptionHandlingRequest
 from get_user import get_user
 
 # ENTRY POINT into the Grinder
@@ -57,6 +58,7 @@ def create_request_obj(test_num, test_name, tgroup_name=None,
     test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)
+    request = ExceptionHandlingRequest(request)
     test.record(request)
     if auth_user:
         request = AuthenticatingRequest(request, auth_user)

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -72,8 +72,6 @@ user = None
 # TODO: re-work how user credentials are retrieved into something like a plugin
 # TODO: system, so that it's more robust, easier to use, and less verbose
 
-
-
 user = get_user(config, grinder)
 
 requests_by_type = {

--- a/scripts/grinder_connector.py
+++ b/scripts/grinder_connector.py
@@ -6,6 +6,19 @@ class ResponseWrapper(object):
     def __init__(self, response):
         self.response = response
 
+    @property
+    def status_code(self):
+        return self.response.getStatusCode()
+
+    @property
+    def headers(self):
+        return dict([(name, self.response.getHeader(name))
+                     for name in self.response.listHeaders()])
+
+    @property
+    def body(self):
+        return self.response.getText()
+
     def json(self):
         return json.loads(self.response.getText())
 

--- a/scripts/grinder_connector.py
+++ b/scripts/grinder_connector.py
@@ -2,7 +2,13 @@
 from net.grinder.plugin.http import HTTPRequest
 from com.xhaus.jyson import JysonCodec as json
 
+
 class ResponseWrapper(object):
+
+    """A wrapper class to make `HTTPClient.HTTPResponse` act more like a
+    `requests.Response`, for interoperability.
+    """
+
     def __init__(self, response):
         self.response = response
 
@@ -24,6 +30,11 @@ class ResponseWrapper(object):
 
 
 class GrinderConnector(object):
+
+    """A connector that makes HTTP requests via The Grinder's worker thread.
+    This is used by the `user.User` class to authenticate.
+    """
+
     def __init__(self):
         self.request = HTTPRequest()
 

--- a/scripts/http_failure_exception.py
+++ b/scripts/http_failure_exception.py
@@ -1,0 +1,11 @@
+
+class HttpFailureException(Exception):
+
+    response = None
+
+    def __init__(self, response):
+        super(HttpFailureException).__init__(
+            self,
+            'The HTTP request did not succeed. Response code %s' %
+            response.getStatusCode())
+        self.response = response

--- a/scripts/http_failure_exception.py
+++ b/scripts/http_failure_exception.py
@@ -4,7 +4,7 @@ class HttpFailureException(Exception):
     response = None
 
     def __init__(self, response):
-        super(HttpFailureException).__init__(
+        super(HttpFailureException, self).__init__(
             self,
             'The HTTP request did not succeed. Response code %s' %
             response.getStatusCode())

--- a/scripts/requests_connector.py
+++ b/scripts/requests_connector.py
@@ -3,5 +3,9 @@ import requests
 
 
 class RequestsConnector(object):
+    """A connector that makes HTTP requests via the `requests` library. This is
+    used in tests of the `user.User` class.
+    """
+
     def post(self, url, body, headers, *args, **kwargs):
         return requests.post(url, json=body, headers=headers, *args, **kwargs)

--- a/scripts/response_checking_request.py
+++ b/scripts/response_checking_request.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+
+class ResponseCheckingRequest():
+    def __init__(self, request):
+        self.request = request
+
+    def check(self, response):
+        if not (200 <= response.getStatusCode() < 300):
+            raise Exception('The HTTP request did not succeed')
+        return response
+
+    def GET(self, *args, **kwargs):
+        return self.check(self.request.GET(*args, **kwargs))
+
+    def HEAD(self, *args, **kwargs):
+        return self.check(self.request.HEAD(*args, **kwargs))
+
+    def POST(self, *args, **kwargs):
+        return self.check(self.request.POST(*args, **kwargs))
+
+    def PUT(self, *args, **kwargs):
+        return self.check(self.request.PUT(*args, **kwargs))
+
+    def DELETE(self, *args, **kwargs):
+        return self.check(self.request.DELETE(*args, **kwargs))
+
+    def OPTIONS(self, *args, **kwargs):
+        return self.check(self.request.OPTIONS(*args, **kwargs))
+
+    def TRACE(self, *args, **kwargs):
+        return self.check(self.request.TRACE(*args, **kwargs))

--- a/scripts/response_checking_request.py
+++ b/scripts/response_checking_request.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from http_failure_exception import HttpFailureException
+
 
 class ResponseCheckingRequest():
     def __init__(self, request):
@@ -7,7 +9,7 @@ class ResponseCheckingRequest():
 
     def check(self, response):
         if not (200 <= response.getStatusCode() < 300):
-            raise Exception('The HTTP request did not succeed')
+            raise HttpFailureException(response)
         return response
 
     def GET(self, *args, **kwargs):

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -16,6 +16,7 @@ class User(object):
 
     token = None
     tenant_id = None
+    logger = None
 
     def __init__(self, auth_url, username, api_key, conn=None):
 
@@ -54,19 +55,24 @@ class User(object):
                             now = datetime.datetime.utcnow()
                             delta = (after - now).total_seconds()
                             if delta > 0:
-                                self.logger('got status code %s, will retry' %
-                                            resp.status_code)
+                                if self.logger:
+                                    self.logger("Got status code %s, will "
+                                                "retry" %
+                                                resp.status_code)
                                 time.sleep(delta)
                     except:
-                        self.logger('got status code %s, can\'t retry' %
-                                    resp.status_code)
+                        if self.logger:
+                            self.logger("Got status code %s, can't retry" %
+                                        resp.status_code)
                         return (None, None)
                 else:
-                    self.logger('got status code %s, won\'t retry' %
-                                resp.status_code)
+                    if self.logger:
+                        self.logger("Got status code %s, won't retry" %
+                                    resp.status_code)
                     return (None, None)
             else:
-                self.logger('Couldn\'t get token and tenant')
+                if self.logger:
+                    self.logger("Couldn't get token and tenant")
                 return (None, None)
 
             catalog = resp.json()

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -67,7 +67,7 @@ class User(object):
                 except:
                     self.logger('got status code %s, can\'t retry' %
                                 resp.status_code)
-                    return (None,None)
+                    return (None, None)
             else:
                 self.logger('got status code %s, won\'t retry' %
                             resp.status_code)

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -1,4 +1,6 @@
 
+import threading
+
 from connector import Connector
 
 try:
@@ -21,8 +23,18 @@ class User(object):
         self.username = username
         self.api_key = api_key
         self.connector = conn
+        self.lock = threading.RLock()
 
     def _get_data(self):
+        self.lock.acquire()
+        try:
+            if self.token is None or self.tenant_id is None:
+                return self._get_data_sync()
+        finally:
+            self.lock.release()
+        return self.tenant_id, self.token
+
+    def _get_data_sync(self):
         request_body = {
             "auth": {
                 "RAX-KSKEY:apiKeyCredentials": {

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -48,9 +48,11 @@ class User(object):
                 if resp.status_code in [413, 429]:
                     try:
                         # TODO: lower/upper case
+                        # https://jira.rax.io/browse/CMD-1449
                         retry_after = resp.headers.get('Retry-After')
                         if retry_after:
                             # TODO: double-check time zone
+                            # https://jira.rax.io/browse/CMD-1449
                             after = email.utils.parsedate(retry_after)
                             now = datetime.datetime.utcnow()
                             delta = (after - now).total_seconds()

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -82,11 +82,9 @@ class User(object):
 
         self.lock.acquire()
         try:
-            if self.token is None or self.tenant_id is None:
-                return get_data_sync()
+            return get_data_sync()
         finally:
             self.lock.release()
-        return self.tenant_id, self.token
 
     def get_token(self):
         if self.token is None:

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -29,56 +29,57 @@ class User(object):
         self.lock = threading.RLock()
 
     def _get_data(self):
-        self.lock.acquire()
-        try:
-            if self.token is None or self.tenant_id is None:
-                return self._get_data_sync()
-        finally:
-            self.lock.release()
-        return self.tenant_id, self.token
-
-    def _get_data_sync(self):
-        request_body = {
-            "auth": {
-                "RAX-KSKEY:apiKeyCredentials": {
-                    "username": self.username,
-                    "apiKey": self.api_key}}}
-        headers = [
-            NVPair("Accept", "application/json"),
-            NVPair("Content-type", "application/json")
-        ]
-        for retries in xrange(3):
-            resp = self.connector.post(self.auth_url, request_body, headers)
-            if 200 <= resp.status_code < 300:
-                break
-            if resp.status_code in [413, 429]:
-                try:
-                    # TODO: lower/upper case
-                    retry_after = resp.headers.get('Retry-After')
-                    if retry_after:
-                        # TODO: double-check time zone
-                        after = email.utils.parsedate(retry_after)
-                        now = datetime.datetime.utcnow()
-                        delta = (after - now).total_seconds()
-                        if delta > 0:
-                            self.logger('got status code %s, will retry' %
-                                        resp.status_code)
-                            time.sleep(delta)
-                except:
-                    self.logger('got status code %s, can\'t retry' %
+        def get_data_sync():
+            request_body = {
+                "auth": {
+                    "RAX-KSKEY:apiKeyCredentials": {
+                        "username": self.username,
+                        "apiKey": self.api_key}}}
+            headers = [
+                NVPair("Accept", "application/json"),
+                NVPair("Content-type", "application/json")
+            ]
+            for retries in xrange(3):
+                resp = self.connector.post(self.auth_url, request_body,
+                                           headers)
+                if 200 <= resp.status_code < 300:
+                    break
+                if resp.status_code in [413, 429]:
+                    try:
+                        # TODO: lower/upper case
+                        retry_after = resp.headers.get('Retry-After')
+                        if retry_after:
+                            # TODO: double-check time zone
+                            after = email.utils.parsedate(retry_after)
+                            now = datetime.datetime.utcnow()
+                            delta = (after - now).total_seconds()
+                            if delta > 0:
+                                self.logger('got status code %s, will retry' %
+                                            resp.status_code)
+                                time.sleep(delta)
+                    except:
+                        self.logger('got status code %s, can\'t retry' %
+                                    resp.status_code)
+                        return (None, None)
+                else:
+                    self.logger('got status code %s, won\'t retry' %
                                 resp.status_code)
                     return (None, None)
             else:
-                self.logger('got status code %s, won\'t retry' %
-                            resp.status_code)
+                self.logger('Couldn\'t get token and tenant')
                 return (None, None)
-        else:
-            self.logger('Couldn\'t get token and tenant')
-            return (None, None)
 
-        catalog = resp.json()
-        self.tenant_id = catalog['access']['token']['tenant']['id']
-        self.token = catalog['access']['token']['id']
+            catalog = resp.json()
+            self.tenant_id = catalog['access']['token']['tenant']['id']
+            self.token = catalog['access']['token']['id']
+            return self.tenant_id, self.token
+
+        self.lock.acquire()
+        try:
+            if self.token is None or self.tenant_id is None:
+                return get_data_sync()
+        finally:
+            self.lock.release()
         return self.tenant_id, self.token
 
     def get_token(self):


### PR DESCRIPTION
Because of the Grinder counts errors in the statistics, the scripts were reporting all HTTP requests as successes, even 500's. This PR adds some logic to check the status code of HTTP responses and raise an exception if the code indicates a failure. This will make Grinder correctly report the number of errors while running the tests.

Also, I noticed that the code for getting a user's token and tenant id had some problems. This PR adds code to retry the call to identity if it gets rate limited, and also makes the process of getting the token thread-safe, so it's less likely to get rate limited in the first place.