### PR TITLE
Count ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]ingest_batch_size` - Ingestion threads will generate this many metrics in a single payload (HTTP request body). Default is `5`.
 * `[grinder.bf.]ingest_delay_millis` - Configures delayed metrics. Default is `""`, which doesn't produced any delayed metrics.
 * `[grinder.bf.]ingest_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `IngestThread` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
+* `[grinder.bf.]ingest_count_raw_metrics` - `True` to create a secondary Grinder `Test` object to track the total number of metrics ingested, not just the number of HTTP requests. The count is increased by the number of metrics in a given POST payload (which should be equal to `ingest_batch_size`), when the given request is successful. Note that this will skew the total TPS and other statistics that Grinder collects. Default is False.
 
 * `[grinder.bf.]annotations_weight` - Default is `5`.
 * `[grinder.bf.]annotations_num_tenants` - Exactly like `ingest_num_tenants`, except that this property controls the number of tenant id's for the `AnnotationsIngestThread` class. This property is provided so that ingest and annotation ingest threads can be configured independently. Default is `5`.

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -13,6 +13,7 @@ from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs
 import abstract_thread
+from raw_ingest_counter import RawIngestCounter
 from throttling_group import ThrottlingGroup
 from throttling_request import ThrottlingRequest
 from authenticating_request import AuthenticatingRequest
@@ -110,6 +111,10 @@ requests_by_type = {
             config.get('annotations_query_throttling_group', None),
             user),
 }
+
+if config.get('ingest_count_raw_metrics', False):
+    test = Test(101, "Metrics Ingested Raw Count")
+    IngestThread.raw_ingest_counter = RawIngestCounter(test)
 
 thread_manager = tm.ThreadManager(config, requests_by_type)
 

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -51,17 +51,12 @@ for k, v in config.iteritems():
         throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
-def create_test_around_object(test_num, test_name, obj):
-    test = Test(test_num, test_name)
-    test.record(obj)
-    return test
-
-
 def create_request_obj(test_num, test_name, tgroup_name=None,
                        auth_user=None):
+    test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)
-    create_test_around_object(test_num, test_name, request)
+    test.record(request)
     request = ExceptionHandlingRequest(request)
     if auth_user:
         request = AuthenticatingRequest(request, auth_user)

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -51,12 +51,17 @@ for k, v in config.iteritems():
         throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
+def create_test_around_object(test_num, test_name, obj):
+    test = Test(test_num, test_name)
+    test.record(obj)
+    return test
+
+
 def create_request_obj(test_num, test_name, tgroup_name=None,
                        auth_user=None):
-    test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)
-    test.record(request)
+    create_test_around_object(test_num, test_name, request)
     request = ExceptionHandlingRequest(request)
     if auth_user:
         request = AuthenticatingRequest(request, auth_user)

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,5 +1,7 @@
 import random
 
+from raw_ingest_counter import NullIngestCounter
+
 try:
     from com.xhaus.jyson import JysonCodec as json
 except ImportError:
@@ -35,6 +37,8 @@ class IngestThread(AbstractThread):
         4: 'years',
         5: 'decades'
     }
+
+    raw_ingest_counter = NullIngestCounter()
 
     def generate_unit(self, tenant_id):
         tenant_id = int_from_tenant(tenant_id)
@@ -85,4 +89,9 @@ class IngestThread(AbstractThread):
         result = self.request.POST(url, payload, headers)
         if result.getStatusCode() >= 400:
             logger("IngestThread Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
+        if 200 <= result.getStatusCode() < 300:
+            self.count_raw_metrics(len(tenant_metric_id_values))
         return result
+
+    def count_raw_metrics(self, n):
+        self.raw_ingest_counter.count(n)

--- a/scripts/raw_ingest_counter.py
+++ b/scripts/raw_ingest_counter.py
@@ -1,0 +1,22 @@
+
+class RawIngestCounter():
+
+    class Target():
+        def target(self):
+            pass
+
+    def __init__(self, test):
+        self.target = self.Target()
+        test.record(self.target)
+
+    def count(self, n=1):
+        for i in xrange(n):
+            self.target.target()
+
+
+class NullIngestCounter():
+    def __init__(self, test=None):
+        pass
+
+    def count(self, n=1):
+        pass


### PR DESCRIPTION
This PR adds an option to count the actual _number_ of metrics sent to the ingest endpoint, and track it in the Grinder UI and logs. It's a little awkward, though, as the way it uses grinder to track the number skews the total counts and TPS. To get an accurate estimate of number of requests per second, you'll have to run analysis on the grinder data log after the test has completed.

This code has already been successfully tried out in a test environment.