### PR TITLE
Re auth when token expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]auth_api_key` - The API key to authenticate with before running the perf test.
 * `[grinder.bf.]auth_properties_path` - Path to a `.properties` file that contains the user credentials. If any of `auth_url`, `auth_username`, or `auth_api_key` is not specified in the main config file, then this property will be checked for credentials. The property file referred to by this property will **only** be checked for user credentials; any other properties defined in it will not be used for any purpose, nor will this `.properties` file in any way override the main config.
 * `[grinder.bf.]auth_properties_encr_key_file` - Path to a `.properties` file that hass a `password` entry giving a simple encryption key. If this property is specified, then properties in the `auth_properties_path` file can be encrypted using jasypt, e.g. `ENC(abc123...)`. The property file referred to by `auth_properties_encr_key_file` will **only** be checked for a `password` property; any other properties defined in it will not be used for any purpose, nor will this property file in any way override the main config.
-* `[grinder.bf.]print_tokens` - True to print authentication tokens to the log when they are retrieved from the identity service. Default is False.
 
 ##Installing
 The following command will download the necessary software packages and place them under the `dependencies/` folder:

--- a/scripts/authenticating_request.py
+++ b/scripts/authenticating_request.py
@@ -50,33 +50,30 @@ class AuthenticatingRequest(object):
 
         return args, kwargs
 
+    def execute_request(self, request_method, headers_arg_index, args, kwargs):
+        args, kwargs = self.authenticate(args, kwargs, headers_arg_index)
+        return request_method(*args, **kwargs)
+
     def GET(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 2)
-        return self.request.GET(*args, **kwargs)
+        return self.execute_request(self.request.GET, 2, args, kwargs)
 
     def HEAD(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 2)
-        return self.request.HEAD(*args, **kwargs)
+        return self.execute_request(self.request.HEAD, 2, args, kwargs)
 
     def POST(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 2)
-        return self.request.POST(*args, **kwargs)
+        return self.execute_request(self.request.POST, 2, args, kwargs)
 
     def PUT(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 2)
-        return self.request.PUT(*args, **kwargs)
+        return self.execute_request(self.request.PUT, 2, args, kwargs)
 
     def DELETE(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 1)
-        return self.request.DELETE(*args, **kwargs)
+        return self.execute_request(self.request.DELETE, 1, args, kwargs)
 
     def OPTIONS(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 2)
-        return self.request.OPTIONS(*args, **kwargs)
+        return self.execute_request(self.request.OPTIONS, 2, args, kwargs)
 
     def TRACE(self, *args, **kwargs):
-        args, kwargs = self.authenticate(args, kwargs, 1)
-        return self.request.TRACE(*args, **kwargs)
+        return self.execute_request(self.request.TRACE, 1, args, kwargs)
 
 
 class NullAuthenticatingRequest(AuthenticatingRequest):

--- a/scripts/authenticating_request.py
+++ b/scripts/authenticating_request.py
@@ -51,8 +51,13 @@ class AuthenticatingRequest(object):
         return args, kwargs
 
     def execute_request(self, request_method, headers_arg_index, args, kwargs):
-        args, kwargs = self.authenticate(args, kwargs, headers_arg_index)
-        return request_method(*args, **kwargs)
+        args1, kwargs1 = self.authenticate(args, kwargs, headers_arg_index)
+        response = request_method(*args1, **kwargs1)
+        if response.getStatusCode() in [401, 403]:
+            self.user.reauthenticate()
+            args2, kwargs2 = self.authenticate(args, kwargs, headers_arg_index)
+            response = request_method(*args2, **kwargs2)
+        return response
 
     def GET(self, *args, **kwargs):
         return self.execute_request(self.request.GET, 2, args, kwargs)

--- a/scripts/authenticating_request.py
+++ b/scripts/authenticating_request.py
@@ -51,6 +51,8 @@ class AuthenticatingRequest(object):
         return args, kwargs
 
     def execute_request(self, request_method, headers_arg_index, args, kwargs):
+        if self.user.is_expired():
+            self.user.reauthenticate()
         args1, kwargs1 = self.authenticate(args, kwargs, headers_arg_index)
         response = request_method(*args1, **kwargs1)
         if response.getStatusCode() in [401, 403]:

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -6,6 +6,7 @@ import time
 import unittest
 import random
 import math
+from datetime import datetime
 
 import ingest
 import query
@@ -87,6 +88,12 @@ class FakeIdentityConnector(object):
     url = None
     json = None
     headers = None
+    expires_timestamp = None
+
+    def __init__(self, expires_timestamp=None):
+        if expires_timestamp is None:
+            expires_timestamp = '2016-01-01T00:00:00.000000Z'
+        self.expires_timestamp = expires_timestamp
 
     def post(self, url, json=None, headers=None):
         self.called = True
@@ -97,6 +104,7 @@ class FakeIdentityConnector(object):
             'access': {
                 'token': {
                     'id': UserTest.token,
+                    'expires': self.expires_timestamp,
                     'tenant': {
                         'id': UserTest.tenant}}}})
 
@@ -880,6 +888,80 @@ class UserTest(TestCaseBase):
 
         # then the token was returned
         self.assertEqual(self.tenant, result)
+
+    def test_gets_expiration_timestamp_from_catalog(self):
+        # given
+        expires_str = '2017-01-01T00:00:00.000000Z'
+        expires_dt = datetime(2017, 1, 1)
+        conn = FakeIdentityConnector(expires_timestamp=expires_str)
+        user = User(self.auth_url, self.username, self.api_key, config={},
+                    conn=conn)
+
+        # when
+        result = user._get_data()
+
+        # then the expiration timestamp was set to the correct value
+        self.assertIsNotNone(user.expires)
+        self.assertEqual(expires_dt, user.expires)
+
+    def test_is_expired_false_when_not_yet_set(self):
+        # given
+        expires_str = '2017-01-01T00:00:00.000000Z'
+        current_time = datetime(2016, 12, 31)
+        conn = FakeIdentityConnector(expires_timestamp=expires_str)
+        user = User(self.auth_url, self.username, self.api_key, config={},
+                    conn=conn)
+
+        # when
+        result = user.is_expired(current_time=current_time)
+
+        # then the token is considered not yet expired
+        self.assertFalse(result)
+
+        # when
+        current_time2 = datetime(2017, 1, 2)
+        result = user.is_expired(current_time=current_time2)
+
+        # then the token is considered not yet expired
+        self.assertFalse(result)
+
+    def test_is_expired_false(self):
+        # given
+        expires_str = '2017-01-01T00:00:00.000000Z'
+        current_time = datetime(2016, 12, 31)
+        conn = FakeIdentityConnector(expires_timestamp=expires_str)
+        user = User(self.auth_url, self.username, self.api_key, config={},
+                    conn=conn)
+
+        user._get_data()
+
+        # precondition
+        self.assertIsNotNone(user.expires)
+
+        # when
+        result = user.is_expired(current_time=current_time)
+
+        # then the token is not yet expired
+        self.assertFalse(result)
+
+    def test_is_expired_true(self):
+        # given
+        expires_str = '2017-01-01T00:00:00.000000Z'
+        current_time = datetime(2017, 1, 2)
+        conn = FakeIdentityConnector(expires_timestamp=expires_str)
+        user = User(self.auth_url, self.username, self.api_key, config={},
+                    conn=conn)
+
+        user._get_data()
+
+        # precondition
+        self.assertIsNotNone(user.expires)
+
+        # when
+        result = user.is_expired(current_time=current_time)
+
+        # then the token is not yet expired
+        self.assertTrue(result)
 
 
 class ConnectorTest(TestCaseBase):

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -114,3 +114,6 @@ class NullUser(object):
 
     def get_tenant_id(self):
         return 'tenantId'
+
+    def reauthenticate(self):
+        return self.get_tenant_id(), self.get_token()

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -17,6 +17,7 @@ class User(object):
     token = None
     tenant_id = None
     logger = None
+    expires = False
 
     def __init__(self, auth_url, username, api_key, config, conn=None):
 
@@ -81,6 +82,9 @@ class User(object):
             catalog = resp.json()
             self.tenant_id = catalog['access']['token']['tenant']['id']
             self.token = catalog['access']['token']['id']
+            expiration_date = catalog['access']['token']['expires']
+            self.expires = datetime.datetime.strptime(expiration_date,
+                                                      "%Y-%m-%dT%H:%M:%S.%fZ")
             if self.config.get('print_tokens', False):
                 self.logger('token for user "%s" is %s' %
                             (self.username, self.token))

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -85,9 +85,6 @@ class User(object):
             expiration_date = catalog['access']['token']['expires']
             self.expires = datetime.datetime.strptime(expiration_date,
                                                       "%Y-%m-%dT%H:%M:%S.%fZ")
-            if self.config.get('print_tokens', False):
-                self.logger('token for user "%s" is %s' %
-                            (self.username, self.token))
             return self.tenant_id, self.token
 
         self.lock.acquire()

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -17,7 +17,7 @@ class User(object):
     token = None
     tenant_id = None
     logger = None
-    expires = False
+    expires = None
 
     def __init__(self, auth_url, username, api_key, config, conn=None):
 
@@ -112,11 +112,14 @@ class User(object):
         self.expires = None
         return self._get_data()
 
-    def is_expired(self):
+    def is_expired(self, current_time=None):
+        if current_time is None:
+            current_time = datetime.datetime.utcnow()
+
         if not self.expires:
             return False
 
-        if datetime.datetime.utcnow() >= self.expires:
+        if current_time >= self.expires:
             return True
 
         return False

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -109,7 +109,17 @@ class User(object):
     def reauthenticate(self):
         self.token = None
         self.tenant_id = None
+        self.expires = None
         return self._get_data()
+
+    def is_expired(self):
+        if not self.expires:
+            return False
+
+        if datetime.datetime.utcnow() >= self.expires:
+            return True
+
+        return False
 
 
 class NullUser(object):

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -102,6 +102,11 @@ class User(object):
             self._get_data()
         return self.tenant_id
 
+    def reauthenticate(self):
+        self.token = None
+        self.tenant_id = None
+        return self._get_data()
+
 
 class NullUser(object):
     def get_token(self):


### PR DESCRIPTION
When the perf tests run for a very long time, the authentication token being used can actually expire. If that happens, all requests should start erroring out. To fix that, this PR adds logic to re-authenticate a request if it gets a 401 or 403 response code. This should in theory be completely transparent to the user.