### PR TITLE
Fix bugs

### DIFF
--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -157,7 +157,9 @@ class TestCaseBase(unittest.TestCase):
 
     def assertIsInstance(self, obj, cls, msg=None):
         return self.assertTrue(isinstance(obj, cls), msg)
-    pass
+
+    def assertIsNotNone(self, expr, msg=None):
+        return self.assertTrue(expr is not None, msg)
 
 
 class ThreadManagerTest(TestCaseBase):

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -788,6 +788,9 @@ class AuthenticatingRequestTest(unittest.TestCase):
             def reauthenticate(self):
                 self.reauthenticated = True
 
+            def is_expired(self):
+                return False
+
         req = MockReqAlways401()
         token = 'token'
         uri = '/path/to/resource'

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -83,8 +83,19 @@ class User(object):
             self.tenant_id = catalog['access']['token']['tenant']['id']
             self.token = catalog['access']['token']['id']
             expiration_date = catalog['access']['token']['expires']
-            self.expires = datetime.datetime.strptime(expiration_date,
-                                                      "%Y-%m-%dT%H:%M:%S.%fZ")
+            try:
+                self.expires = datetime.datetime.strptime(expiration_date,
+                                                          "%Y-%m-%dT%H:%M:%S.%fZ")
+            except:
+                parts = expiration_date.split('.')
+                dt = datetime.datetime.strptime(parts[0], "%Y-%m-%dT%H:%M:%S")
+                if len(parts) > 1:
+                    microseconds = parts[1]
+                    if microseconds.endswith('Z'):
+                        microseconds = microseconds[0:-1]
+                    dt = dt.replace(microsecond=int(microseconds))
+                self.expires = dt
+                pass
             return self.tenant_id, self.token
 
         self.lock.acquire()

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -142,3 +142,6 @@ class NullUser(object):
 
     def reauthenticate(self):
         return self.get_tenant_id(), self.get_token()
+
+    def is_expired(self):
+        return False


### PR DESCRIPTION
Some bugs were introduced in #14, related to re-authenticating. They slipped through because they only show up when running under Jython, 2.5, and not Python 2.7. In particular, Python/Jython is not able to use the `%f` formatting directive to parse timestamps for token expiration.

This PR fixes them.