### PR TITLE
Fix throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]name_fmt` - Default is `org.example.metric.%d`.
 
 * `[grinder.bf.]throttling_group.<name>.max_requests_per_minute` - Create a throttling group with the given `name`. The value of the property is taken as the throttling group's `max_requests_per_minute` parameter. By default, no throttling groups are created if no properties are specified.
-* `[grinder.bf.]throttling_group.<name>.type` - Optionally specify the type of
-throttling group. Possible values are `smooth` and `default`. `default` divides
-time up into 60-second intervals. Requests will run at full speed until the
-limit is reached, and then the throttler will block all requests until the
-60-second interval has elapsed. This tends to cause "bursts" of requests,
-interleaved with periods of silence. `smooth` tries to space out requests
-evenly, such that there are no great bursts, but tends to allow slightly fewer
-total requests than `max_requests_per_minute`. If the property is not
-specified, or if it is empty, or it is not one of the allowed values, `default`
-is assumed.
 
 * `[grinder.bf.]ingest_weight` - Default is `15`.
 * `[grinder.bf.]ingest_num_tenants` - Ingestion threads randomly generate a numerical tenant id in the range of `[0,ingest_num_tenants)`. Change this property to control how many different tenant id's are used when sending standard metrics to the service. Default is `4`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]name_fmt` - Default is `org.example.metric.%d`.
 
 * `[grinder.bf.]throttling_group.<name>.max_requests_per_minute` - Create a throttling group with the given `name`. The value of the property is taken as the throttling group's `max_requests_per_minute` parameter. By default, no throttling groups are created if no properties are specified.
+* `[grinder.bf.]throttling_group.<name>.type` - Optionally specify the type of
+throttling group. Possible values are `smooth` and `default`. `default` divides
+time up into 60-second intervals. Requests will run at full speed until the
+limit is reached, and then the throttler will block all requests until the
+60-second interval has elapsed. This tends to cause "bursts" of requests,
+interleaved with periods of silence. `smooth` tries to space out requests
+evenly, such that there are no great bursts, but tends to allow slightly fewer
+total requests than `max_requests_per_minute`. If the property is not
+specified, or if it is empty, or it is not one of the allowed values, `default`
+is assumed.
 
 * `[grinder.bf.]ingest_weight` - Default is `15`.
 * `[grinder.bf.]ingest_num_tenants` - Ingestion threads randomly generate a numerical tenant id in the range of `[0,ingest_num_tenants)`. Change this property to control how many different tenant id's are used when sending standard metrics to the service. Default is `4`.

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -49,19 +49,26 @@ for k, v in config.iteritems():
         str(k))
     if m:
         name = m.groups()[-1]
+        grinder.logger.info('Instantiating throttling group named "%s", with '
+                            'max rpm=%d' % (name, int(v)))
         throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
 def create_request_obj(test_num, test_name, tgroup_name=None,
                        auth_user=None):
+    grinder.logger.info('Creating %s request object')
     test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)
     test.record(request)
     request = ExceptionHandlingRequest(request)
     if auth_user:
+        grinder.logger.info('%s request object will authenticate with '
+                            'username "%s".' % (test_name, auth_user.username))
         request = AuthenticatingRequest(request, auth_user)
     if tgroup_name:
+        grinder.logger.info('%s request object will throttle with group '
+                            '"%s".' % (test_name, tgroup_name))
         tgroup = throttling_groups[tgroup_name]
         request = ThrottlingRequest(tgroup, request)
     return request

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -14,7 +14,7 @@ from query import AnnotationsQuery
 from config import clean_configs
 import abstract_thread
 from raw_ingest_counter import RawIngestCounter
-from throttling_group import ThrottlingGroup
+from throttling_group import ThrottlingGroup, SmoothThrottlingGroup
 from throttling_request import ThrottlingRequest
 from authenticating_request import AuthenticatingRequest
 from response_checking_request import ResponseCheckingRequest
@@ -49,9 +49,17 @@ for k, v in config.iteritems():
         str(k))
     if m:
         name = m.groups()[-1]
+        tgroup_type_prop_name = ('throttling_group.%s.type' % name)
+        if config.get(type_prop_name, None) == 'smooth':
+            tgroup_type_s = 'smooth'
+            tgroup_type = SmoothThrottlingGroup
+        else:
+            tgroup_type_s = 'default'
+            tgroup_type = ThrottlingGroup
         grinder.logger.info('Instantiating throttling group named "%s", with '
-                            'max rpm=%d' % (name, int(v)))
-        throttling_groups[name] = ThrottlingGroup(name, int(v))
+                            'max rpm=%d, type=%s' %
+                            (name, int(v), tgroup_type_s))
+        throttling_groups[name] = tgroup_type(name, int(v))
 
 
 def create_request_obj(test_num, test_name, tgroup_name=None,

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -50,7 +50,7 @@ for k, v in config.iteritems():
     if m:
         name = m.groups()[-1]
         tgroup_type_prop_name = ('throttling_group.%s.type' % name)
-        if config.get(type_prop_name, None) == 'smooth':
+        if config.get(tgroup_type_prop_name, None) == 'smooth':
             tgroup_type_s = 'smooth'
             tgroup_type = SmoothThrottlingGroup
         else:

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -50,25 +50,25 @@ for k, v in config.iteritems():
     if m:
         name = m.groups()[-1]
         tgroup_type_prop_name = ('throttling_group.%s.type' % name)
-        grinder.logger.info('Instantiating throttling group named "%s", with '
-                            'max rpm=%d' % (name, int(v)))
+        grinder.logger.debug('Instantiating throttling group named "%s", with '
+                             'max rpm=%d' % (name, int(v)))
         throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
 def create_request_obj(test_num, test_name, tgroup_name=None,
                        auth_user=None):
-    grinder.logger.info('Creating %s request object' % test_name)
+    grinder.logger.debug('Creating %s request object' % test_name)
     test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)
     test.record(request)
     request = ExceptionHandlingRequest(request)
     if auth_user:
-        grinder.logger.info('%s request object will authenticate with '
+        grinder.logger.debug('%s request object will authenticate with '
                             'username "%s".' % (test_name, auth_user.username))
         request = AuthenticatingRequest(request, auth_user)
     if tgroup_name:
-        grinder.logger.info('%s request object will throttle with group '
+        grinder.logger.debug('%s request object will throttle with group '
                             '"%s".' % (test_name, tgroup_name))
         tgroup = throttling_groups[tgroup_name]
         request = ThrottlingRequest(tgroup, request)
@@ -134,8 +134,8 @@ class TestRunner:
         self.thread = thread_manager.setup_thread(
             thread_number, agent_number, throttling_groups, user)
         worker_type = type(self.thread)
-        grinder.logger.info('Worker %s-%s type %s' %
-                            (agent_number, thread_number, worker_type))
+        grinder.logger.debug('Worker %s-%s type %s' %
+                             (agent_number, thread_number, worker_type))
 
     def __call__(self):
         result = self.thread.make_request(grinder.logger.info,

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -14,7 +14,7 @@ from query import AnnotationsQuery
 from config import clean_configs
 import abstract_thread
 from raw_ingest_counter import RawIngestCounter
-from throttling_group import ThrottlingGroup, SmoothThrottlingGroup
+from throttling_group import ThrottlingGroup
 from throttling_request import ThrottlingRequest
 from authenticating_request import AuthenticatingRequest
 from response_checking_request import ResponseCheckingRequest
@@ -50,16 +50,9 @@ for k, v in config.iteritems():
     if m:
         name = m.groups()[-1]
         tgroup_type_prop_name = ('throttling_group.%s.type' % name)
-        if config.get(tgroup_type_prop_name, None) == 'smooth':
-            tgroup_type_s = 'smooth'
-            tgroup_type = SmoothThrottlingGroup
-        else:
-            tgroup_type_s = 'default'
-            tgroup_type = ThrottlingGroup
         grinder.logger.info('Instantiating throttling group named "%s", with '
-                            'max rpm=%d, type=%s' %
-                            (name, int(v), tgroup_type_s))
-        throttling_groups[name] = tgroup_type(name, int(v))
+                            'max rpm=%d' % (name, int(v)))
+        throttling_groups[name] = ThrottlingGroup(name, int(v))
 
 
 def create_request_obj(test_num, test_name, tgroup_name=None,

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -56,7 +56,7 @@ for k, v in config.iteritems():
 
 def create_request_obj(test_num, test_name, tgroup_name=None,
                        auth_user=None):
-    grinder.logger.info('Creating %s request object')
+    grinder.logger.info('Creating %s request object' % test_name)
     test = Test(test_num, test_name)
     request = HTTPRequest()
     request = ResponseCheckingRequest(request)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -652,7 +652,8 @@ class ThrottlingGroupTest(unittest.TestCase):
         last_time_returned = [None]
 
         def time_source():
-            # this time source returns a fixed sequence of numbers
+            # This time source returns a fixed sequence of numbers.
+            # First it will return 0, then it will return 61.
             t = times()
             last_time_returned[0] = t
             return t
@@ -673,13 +674,18 @@ class ThrottlingGroupTest(unittest.TestCase):
         # then it increments the count and doesn't sleep
         self.assertEquals(1, tg.count)
         self.assertEquals([], sleeps)
+        self.assertEqual(0, last_time_returned[0])
 
-        # when we count the second request
+        # when we count the second request (due to time_source, from the
+        # ThrottlingGroup's perspective, 60 seconds have transpired)
         tg.count_request()
 
-        # then it resets the count to one and doesn't sleep
+        # then it resets the count to one and doesn't sleep. that is, the
+        # one-minute timeout transpired, so the next request shouldn't be
+        # throttled.
         self.assertEquals(1, tg.count)
         self.assertEquals([], sleeps)
+        self.assertEqual(61, last_time_returned[0])
 
 
 class ThreadsWithThrottlingGroupTest(unittest.TestCase):

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -48,7 +48,7 @@ class ThrottlingGroup(object):
             t2 = t1
             delta_n = delta / self.seconds_per_request
             n += delta_n
-            if n > 1:
+            if n >= 1:
                 count = int(math.floor(n))
                 n -= count
                 for i in xrange(count):

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -7,59 +7,16 @@ from Queue import Queue
 
 
 class ThrottlingGroup(object):
-
     """Throttling groups allow you to limit the number of requests made by
      threads. Separate threads can share a single ThrottlingGroup object, so
-     that they all count towards the limit. If a request puts a given
-     throttling group over its limit, then the thread that is trying to send
-     the request will sleep until the 1-minute interval has completed. All
-     other threads that attempt to send a request during that time will block.
+     that they all count towards the limit. The ThrottlingGroup object uses a
+     background thread to coordinate the timing of requests. Requests will be
+     made at an interval approximately long enough to keep the total number of
+     requests for a given 60-second timespan at or below the configured limit.
+     Typically, in practice, timing and calculation overhead will keep the
+     number of requests at about 95% of the configured limit.
     """
 
-    def __init__(self, name, max_requests_per_minute, time_source=None,
-                 sleep_source=None):
-
-        if time_source is None:
-            time_source = time.time
-        if sleep_source is None:
-            sleep_source = time.sleep
-
-        self.name = name
-        self.max_requests_per_minute = max_requests_per_minute
-        self.count = 0
-        self.lock = threading.Lock()
-        self.start_time = -1
-        self.time_source = time_source
-        self.sleep_source = sleep_source
-
-    def count_request(self):
-        with self.lock:
-            current_time = self.time_source()
-            if self.start_time < 0:
-                self.count += 1
-                self.start_time = current_time
-                return
-
-            seconds_since_start = current_time - self.start_time
-            if seconds_since_start >= 60:
-                self.count = 1
-                self.start_time = current_time
-            elif self.count < self.max_requests_per_minute:
-                self.count += 1
-            else:
-                seconds_to_wait = self.start_time + 60 - current_time
-                if seconds_to_wait > 0:
-                    self.sleep_source(seconds_to_wait)
-                self.count = 1
-                self.start_time = self.time_source()
-
-
-class NullThrottlingGroup(object):
-    def count_request(self):
-        pass
-
-
-class SmoothThrottlingGroup(object):
     def __init__(self, name, max_requests_per_minute, time_source=None,
                  sleep_source=None):
 
@@ -89,3 +46,8 @@ class SmoothThrottlingGroup(object):
     def count_request(self):
         self.q.put(None)
         self.semaphore.acquire()
+
+
+class NullThrottlingGroup(object):
+    def count_request(self):
+        pass

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -32,12 +32,12 @@ class ThrottlingGroup(object):
         self.sleep_source = sleep_source
         self.q = Queue()
         self.semaphore = threading.Semaphore(0)
-        self.throttler_thread = threading.Thread(target=self.throttler,
+        self.throttler_thread = threading.Thread(target=self.__throttler,
                                                  name=name)
         self.throttler_thread.setDaemon(True)
         self.throttler_thread.start()
 
-    def throttler(self):
+    def __throttler(self):
         """
         This method should not be called directly. It will be run in a separate
         thread. It synchronizes requests using a locked producer/consumer

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -74,7 +74,7 @@ class SmoothThrottlingGroup(object):
         self.time_source = time_source
         self.sleep_source = sleep_source
         self.q = Queue()
-        self.semaphore = threading.Semaphore()
+        self.semaphore = threading.Semaphore(0)
         self.throttler_thread = threading.Thread(target=self.throttler,
                                                  name=name)
         self.throttler_thread.setDaemon(True)

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -38,6 +38,17 @@ class ThrottlingGroup(object):
         self.throttler_thread.start()
 
     def throttler(self):
+        """
+        This method should not be called directly. It will be run in a separate
+        thread. It synchronizes requests using a locked producer/consumer
+        pattern. When another thread wants to make a request, it will call
+        `q.put()` in count_request and then wait to acquire the semaphore. This
+        method will then sleep for the configured amount of time, if it isn't
+        already. After sleeping, it will release the semaphore, which will
+        allow the other thread to continue with the request. If this method
+        sleeps too long (i.e. `sleep()` is not always exact), it will release
+        the semaphore multiple time to allow the other threads to catch up.
+        """
         t2 = self.time_source()
         n = 0
         self.q.get()

--- a/scripts/util_measure_throttling.py
+++ b/scripts/util_measure_throttling.py
@@ -5,7 +5,7 @@ import locale
 import argparse
 
 from throttling_request import ThrottlingRequest
-from throttling_group import ThrottlingGroup
+from throttling_group import ThrottlingGroup, SmoothThrottlingGroup
 
 locale.setlocale(locale.LC_ALL, 'en_US')
 
@@ -47,15 +47,25 @@ def main():
                         help='How long to run the test.')
     parser.add_argument('--max-rpm', type=int, default=1000,
                         help='Maximum requests per minute')
+    parser.add_argument('--smooth', action='store_true',
+                        help='Use the smooth throttling group, instead of the '
+                             'default.')
 
     args = parser.parse_args()
 
     print('Max requests per minute: %s' % str(args.max_rpm))
     print('Run length in seconds: %s' % str(args.run_seconds))
+    if args.smooth:
+        print('Throttling group type: smooth')
+    else:
+        print('Throttling group type: default')
 
     req0 = MeasuringRequest()
 
-    tgroup = ThrottlingGroup('name', args.max_rpm)
+    if args.smooth:
+        tgroup = SmoothThrottlingGroup('name', args.max_rpm)
+    else:
+        tgroup = ThrottlingGroup('name', args.max_rpm)
     req = ThrottlingRequest(tgroup, req0)
 
     start_time = time.time()

--- a/scripts/util_measure_throttling.py
+++ b/scripts/util_measure_throttling.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import time
+import locale
+import argparse
+
+from throttling_request import ThrottlingRequest
+from throttling_group import ThrottlingGroup
+
+locale.setlocale(locale.LC_ALL, 'en_US')
+
+
+class MeasuringRequest(object):
+    count = 0
+    last_t = 0
+    rpm = 0
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.count = 0
+        self.last_t = time.time()
+
+    def GET(self, *args, **kwargs):
+        self.count += 1
+        t = time.time()
+        delta = t - self.last_t
+        if delta > 1:
+            self.rpm = self.count * 60 / delta
+            self.count = 0
+            self.last_t = t
+            print(locale.format("%d", self.rpm, grouping=True) +
+                  " requests per minute")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--run-seconds', type=float, default=180,
+                        help='How long to run the test.')
+    parser.add_argument('--max-rpm', type=int, default=1000,
+                        help='Maximum requests per minute')
+
+    args = parser.parse_args()
+
+    req0 = MeasuringRequest()
+
+    tgroup = ThrottlingGroup('name', args.max_rpm)
+    req = ThrottlingRequest(tgroup, req0)
+
+    start_time = time.time()
+    while True:
+        req.GET()
+        t = time.time()
+        if t - start_time > args.run_seconds:
+            break
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/util_measure_throttling.py
+++ b/scripts/util_measure_throttling.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
+import threading
 import time
 import locale
 import argparse
+import logging
 
 from throttling_request import ThrottlingRequest
 from throttling_group import ThrottlingGroup
@@ -16,29 +18,53 @@ class MeasuringRequest(object):
     rpm = 0
     start_time = 0
 
-    def __init__(self):
+    def __init__(self, sleep_seconds=None, report_seconds=None):
         self.reset()
+        self.sleep_seconds = sleep_seconds
+        if report_seconds is None:
+            report_seconds = 1
+        self.report_seconds = report_seconds
 
     def reset(self):
         self.count = 0
         self.last_t = time.time()
 
     def GET(self, *args, **kwargs):
+        if self.sleep_seconds:
+            time.sleep(self.sleep_seconds)
         self.count += 1
         t = time.time()
         delta = t - self.last_t
-        if delta > 1:
+        if delta > self.report_seconds:
             self.rpm = self.count * 60 / delta
             self.count = 0
             self.last_t = t
             print(
-                ("%d seconds elapsed, running at about " % (t -
+                ("%f seconds elapsed, running at about " % (t -
                                                             self.start_time)) +
                 locale.format("%d", self.rpm, grouping=True) +
-                " requests per minute")
+                " requests per minute.")
 
     def start(self):
         self.start_time = time.time()
+
+    def finish(self):
+        t = time.time()
+        delta = t - self.last_t
+        self.rpm = self.count * 60 / delta
+        print(
+            ("%f seconds elapsed, running at about " % (t -
+                                                        self.start_time)) +
+            locale.format("%d", self.rpm, grouping=True) +
+            " requests per minute.")
+
+
+def loop(start_time, req, run_seconds):
+    while True:
+        req.GET()
+        t = time.time()
+        if t - start_time > run_seconds:
+            break
 
 
 def main():
@@ -47,25 +73,65 @@ def main():
                         help='How long to run the test.')
     parser.add_argument('--max-rpm', type=int, default=1000,
                         help='Maximum requests per minute')
+    parser.add_argument('--log', action='store_true',
+                        help='Print additional diagnostic information.')
+    parser.add_argument('--threads', action='store', type=int, default=1,
+                        help='The number of threads to make requests with.')
+    parser.add_argument('--no-throttling', action='store_true',
+                        help='Turn off throttling completely. Requests will '
+                             'run as fast as possible. This causes the '
+                             'program to ignore the --max-rpm argument.')
+    parser.add_argument('--sleep-seconds', type=float,
+                        help='time in seconds to sleep at the beginning of '
+                             'the GET method.')
+    parser.add_argument('--report-seconds', type=float, default=1,
+                        help='Time in seconds in between reporting estimated '
+                             'average requests per second.')
 
     args = parser.parse_args()
 
-    print('Max requests per minute: %s' % str(args.max_rpm))
-    print('Run length in seconds: %s' % str(args.run_seconds))
+    if args.log:
+        logging.basicConfig(
+            format="%(asctime)-15s %(thread)d %(method)-32s %(message)s",
+            level=logging.INFO)
 
-    req0 = MeasuringRequest()
+    max_rpm = args.max_rpm
+    run_seconds = args.run_seconds
+    sleep_seconds = args.sleep_seconds
+    report_seconds = args.report_seconds
+    no_throttling = args.no_throttling
+    num_threads = args.threads
 
-    tgroup = ThrottlingGroup('name', args.max_rpm)
-    req = ThrottlingRequest(tgroup, req0)
+    print('Max requests per minute: %s' % str(max_rpm))
+    print('Run length in seconds: %s' % str(run_seconds))
+    print('Sleep length in seconds: %s' % str(sleep_seconds))
+    print('Report numbers every %s seconds' % str(report_seconds))
+    print('Throttling is %s' % ('disabled' if no_throttling else 'enabled'))
+    print('Number of threads: %s' % str(num_threads))
+
+    req0 = MeasuringRequest(sleep_seconds=sleep_seconds,
+                            report_seconds=report_seconds)
+
+    tgroup = ThrottlingGroup('name', max_rpm)
+    print('tgroup.seconds_per_request: %s' % float(tgroup.seconds_per_request))
+    if no_throttling:
+        req = req0
+    else:
+        req = ThrottlingRequest(tgroup, req0)
 
     start_time = time.time()
     req0.start()
-    while True:
-        req.GET()
-        t = time.time()
-        if t - start_time > args.run_seconds:
-            break
+    threads = []
+    for i in xrange(num_threads):
+        th = threading.Thread(target=loop, name='thread-{}'.format(i),
+                              args=(start_time, req, run_seconds))
+        th.start()
+        threads.append(th)
 
+    for th in threads:
+        th.join()
+
+    req0.finish()
 
 if __name__ == '__main__':
     main()

--- a/scripts/util_measure_throttling.py
+++ b/scripts/util_measure_throttling.py
@@ -14,6 +14,7 @@ class MeasuringRequest(object):
     count = 0
     last_t = 0
     rpm = 0
+    start_time = 0
 
     def __init__(self):
         self.reset()
@@ -30,8 +31,13 @@ class MeasuringRequest(object):
             self.rpm = self.count * 60 / delta
             self.count = 0
             self.last_t = t
-            print(locale.format("%d", self.rpm, grouping=True) +
-                  " requests per minute")
+            print(
+                ("%d seconds elapsed, running at about " % (t - self.start_time)) +
+                locale.format("%d", self.rpm, grouping=True) +
+                " requests per minute")
+
+    def start(self):
+        self.start_time = time.time()
 
 
 def main():
@@ -43,12 +49,16 @@ def main():
 
     args = parser.parse_args()
 
+    print('Max requests per minute: %s' % str(args.max_rpm))
+    print('Run length in seconds: %s' % str(args.run_seconds))
+
     req0 = MeasuringRequest()
 
     tgroup = ThrottlingGroup('name', args.max_rpm)
     req = ThrottlingRequest(tgroup, req0)
 
     start_time = time.time()
+    req0.start()
     while True:
         req.GET()
         t = time.time()

--- a/scripts/util_measure_throttling.py
+++ b/scripts/util_measure_throttling.py
@@ -32,7 +32,8 @@ class MeasuringRequest(object):
             self.count = 0
             self.last_t = t
             print(
-                ("%d seconds elapsed, running at about " % (t - self.start_time)) +
+                ("%d seconds elapsed, running at about " % (t -
+                                                            self.start_time)) +
                 locale.format("%d", self.rpm, grouping=True) +
                 " requests per minute")
 

--- a/scripts/util_measure_throttling.py
+++ b/scripts/util_measure_throttling.py
@@ -5,7 +5,7 @@ import locale
 import argparse
 
 from throttling_request import ThrottlingRequest
-from throttling_group import ThrottlingGroup, SmoothThrottlingGroup
+from throttling_group import ThrottlingGroup
 
 locale.setlocale(locale.LC_ALL, 'en_US')
 
@@ -47,25 +47,15 @@ def main():
                         help='How long to run the test.')
     parser.add_argument('--max-rpm', type=int, default=1000,
                         help='Maximum requests per minute')
-    parser.add_argument('--smooth', action='store_true',
-                        help='Use the smooth throttling group, instead of the '
-                             'default.')
 
     args = parser.parse_args()
 
     print('Max requests per minute: %s' % str(args.max_rpm))
     print('Run length in seconds: %s' % str(args.run_seconds))
-    if args.smooth:
-        print('Throttling group type: smooth')
-    else:
-        print('Throttling group type: default')
 
     req0 = MeasuringRequest()
 
-    if args.smooth:
-        tgroup = SmoothThrottlingGroup('name', args.max_rpm)
-    else:
-        tgroup = ThrottlingGroup('name', args.max_rpm)
+    tgroup = ThrottlingGroup('name', args.max_rpm)
     req = ThrottlingRequest(tgroup, req0)
 
     start_time = time.time()


### PR DESCRIPTION
This PR changes how the `ThrottlingGroup` limits the rate of requests. In particular, it tries to keep a steady, evenly-spaced sequence of requests at the configured rate.