### PR TITLE
change queries to use resolution=MIN5

### DIFF
--- a/scripts/query.py
+++ b/scripts/query.py
@@ -39,7 +39,7 @@ class SinglePlotQuery(AbstractQuery):
                 self.config)
         to = time
         frm = time - self.one_day
-        resolution = 'FULL'
+        resolution = 'MIN5'
         url = "%s/v2.0/%s/views/%s?from=%d&to=%s&resolution=%s" % (
             self.config['query_url'],
             tenant_id, metric_name, frm,
@@ -67,7 +67,7 @@ class MultiPlotQuery(AbstractQuery):
             payload = self.generate_multiplot_payload()
         to = time
         frm = time - self.one_day
-        resolution = 'FULL'
+        resolution = 'MIN5'
         url = "%s/v2.0/%s/views?from=%d&to=%d&resolution=%s" % (
             self.config['query_url'],
             tenant_id, frm,

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -558,7 +558,7 @@ class MakeQueryRequestsTest(TestCaseBase):
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/0/views/" +
                          "org.example.metric.metric123?from=-86399000&" +
-                         "to=1000&resolution=FULL")
+                         "to=1000&resolution=MIN5")
         self.assertIs(req, response.request)
 
     def test_query_make_SearchQuery_request(self):
@@ -588,7 +588,7 @@ class MakeQueryRequestsTest(TestCaseBase):
         response = qq.make_request(None, 1000, 20, payload_sent)
         self.assertEqual(req.post_url,
                          "http://metrics.example.org/v2.0/20/views?" +
-                         "from=-86399000&to=1000&resolution=FULL")
+                         "from=-86399000&to=1000&resolution=MIN5")
         self.assertEqual(req.post_payload, payload_sent)
         self.assertIs(req, response.request)
 


### PR DESCRIPTION
For performance tests, we are pushing tons of the same metrics over and over again. The query code is using resolution=FULL, fetching a day's worth of data points. This is a LOT of datapoints and it will drive (and has driven) the query nodes to OOM. 

Just for a comparison, I looked at some metrics that were fetched with resolution=FULL in Prod env. Those metrics have about 4000 - 6000 datapoints ***total*** (for 3 days) in metrics_full. 

When trying to do the same in perf02, my cqlsh timedout. When I set timeout to something large, like this:
```
/opt/cassandra/bin/cqlsh 10.184.7.5 --request-timeout=3600
```
the query is still running 😝 

My point is: fetching resolution=FULL during performance test is not a realistic request compared to what happens in Prod.

I am changing grinder to use resolution=MIN5