### PR TITLE
Rename thread to generator - part 1 of 3

### DIFF
--- a/scripts/abstract_thread.py
+++ b/scripts/abstract_thread.py
@@ -35,7 +35,7 @@ default_config = {
     'annotations_query_weight': 8}
 
 
-class AbstractThread(object):
+class AbstractGenerator(object):
     # superclass for the various thread types
 
     def make_request(self, logger, time):

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -14,7 +14,7 @@ except ImportError:
     from nvpair import NVPair
 
 
-class AnnotationsIngestThread(AbstractGenerator):
+class AnnotationsIngestGenerator(AbstractGenerator):
 
     def generate_annotation(self, time, metric_id):
         metric_name = generate_metric_name(metric_id, self.config)

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -5,7 +5,7 @@ try:
     from com.xhaus.jyson import JysonCodec as json
 except ImportError:
     import json
-from abstract_thread import AbstractThread, generate_metric_name
+from abstract_thread import AbstractGenerator, generate_metric_name
 from throttling_group import NullThrottlingGroup
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
     from nvpair import NVPair
 
 
-class AnnotationsIngestThread(AbstractThread):
+class AnnotationsIngestThread(AbstractGenerator):
 
     def generate_annotation(self, time, metric_id):
         metric_name = generate_metric_name(metric_id, self.config)

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -7,7 +7,7 @@ from net.grinder.plugin.http import HTTPRequest
 
 import thread_manager as tm
 import py_java
-from annotationsingest import AnnotationsIngestThread
+from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
 from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
@@ -88,7 +88,7 @@ requests_by_type = {
             "Ingest test",
             config.get('ingest_throttling_group', None),
             user),
-    AnnotationsIngestThread:
+    AnnotationsIngestGenerator:
         create_request_obj(
             2,
             "Annotations Ingest test",

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -9,7 +9,7 @@ import thread_manager as tm
 import py_java
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
+from query import SinglePlotQueryGenerator, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs
 import abstract_thread
@@ -94,7 +94,7 @@ requests_by_type = {
             "Annotations Ingest test",
             config.get('annotations_throttling_group', None),
             user),
-    SinglePlotQuery:
+    SinglePlotQueryGenerator:
         create_request_obj(
             3,
             "SinglePlotQuery",

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -9,7 +9,7 @@ import thread_manager as tm
 import py_java
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQueryGenerator, MultiPlotQuery, SearchQuery
+from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs
 import abstract_thread
@@ -100,7 +100,7 @@ requests_by_type = {
             "SinglePlotQuery",
             config.get('singleplot_query_throttling_group', None),
             user),
-    MultiPlotQuery:
+    MultiPlotQueryGenerator:
         create_request_obj(
             4,
             "MultiPlotQuery",

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -9,7 +9,7 @@ import thread_manager as tm
 import py_java
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQuery
+from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQueryGenerator
 from query import AnnotationsQuery
 from config import clean_configs
 import abstract_thread
@@ -106,7 +106,7 @@ requests_by_type = {
             "MultiPlotQuery",
             config.get('multiplot_query_throttling_group', None),
             user),
-    SearchQuery:
+    SearchQueryGenerator:
         create_request_obj(
             5,
             "SearchQuery",

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -9,8 +9,8 @@ import thread_manager as tm
 import py_java
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQueryGenerator
-from query import AnnotationsQueryGenerator
+from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator
+from query import SearchQueryGenerator, AnnotationsQueryGenerator
 from config import clean_configs
 import abstract_thread
 from raw_ingest_counter import RawIngestCounter

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -10,7 +10,7 @@ import py_java
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
 from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQueryGenerator
-from query import AnnotationsQuery
+from query import AnnotationsQueryGenerator
 from config import clean_configs
 import abstract_thread
 from raw_ingest_counter import RawIngestCounter
@@ -112,7 +112,7 @@ requests_by_type = {
             "SearchQuery",
             config.get('search_query_throttling_group', None),
             user),
-    AnnotationsQuery:
+    AnnotationsQueryGenerator:
         create_request_obj(
             6,
             "AnnotationsQuery",

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -8,7 +8,7 @@ from net.grinder.plugin.http import HTTPRequest
 import thread_manager as tm
 import py_java
 from annotationsingest import AnnotationsIngestThread
-from ingest import IngestThread
+from ingest import IngestGenerator
 from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs
@@ -82,7 +82,7 @@ user = None
 user = get_user(config, grinder)
 
 requests_by_type = {
-    IngestThread:
+    IngestGenerator:
         create_request_obj(
             1,
             "Ingest test",
@@ -122,7 +122,7 @@ requests_by_type = {
 
 if config.get('ingest_count_raw_metrics', False):
     test = Test(101, "Metrics Ingested Raw Count")
-    IngestThread.raw_ingest_counter = RawIngestCounter(test)
+    IngestGenerator.raw_ingest_counter = RawIngestCounter(test)
 
 thread_manager = tm.ThreadManager(config, requests_by_type)
 

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -6,7 +6,7 @@ try:
     from com.xhaus.jyson import JysonCodec as json
 except ImportError:
     import json
-from abstract_thread import AbstractThread, generate_metric_name
+from abstract_thread import AbstractGenerator, generate_metric_name
 from throttling_group import NullThrottlingGroup
 
 try:
@@ -27,7 +27,7 @@ def int_from_tenant(tenant_id):
     return hash(tenant_id)
 
 
-class IngestThread(AbstractThread):
+class IngestThread(AbstractGenerator):
 
     units_map = {
         0: 'minutes',

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -27,7 +27,7 @@ def int_from_tenant(tenant_id):
     return hash(tenant_id)
 
 
-class IngestThread(AbstractGenerator):
+class IngestGenerator(AbstractGenerator):
 
     units_map = {
         0: 'minutes',

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -101,7 +101,7 @@ class SearchQueryGenerator(AbstractQueryGenerator):
         return result
 
 
-class AnnotationsQuery(AbstractQueryGenerator):
+class AnnotationsQueryGenerator(AbstractQueryGenerator):
     query_interval_name = 'annotations_query_weight'
 
     def make_request(self, logger, time, tenant_id=None):

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -26,7 +26,7 @@ class AbstractQueryGenerator(AbstractGenerator):
         self.request = request
 
 
-class SinglePlotQuery(AbstractQueryGenerator):
+class SinglePlotQueryGenerator(AbstractQueryGenerator):
     query_interval_name = 'singleplot_query_weight'
 
     def make_request(self, logger, time, tenant_id=None,

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -4,7 +4,7 @@ try:
     from com.xhaus.jyson import JysonCodec as json
 except ImportError:
     import json
-from abstract_thread import AbstractThread, generate_metric_name
+from abstract_thread import AbstractGenerator, generate_metric_name
 from throttling_group import NullThrottlingGroup
 
 try:
@@ -13,14 +13,14 @@ except ImportError:
     from nvpair import NVPair
 
 
-class AbstractQuery(AbstractThread):
+class AbstractQuery(AbstractGenerator):
     one_day = (1000 * 60 * 60 * 24)
 
     query_interval_name = None
 
     def __init__(self, thread_num, agent_number, request, config, user=None):
-        AbstractThread.__init__(self, thread_num, agent_number, request,
-                                config, user)
+        AbstractGenerator.__init__(self, thread_num, agent_number, request,
+                                   config, user)
         self.thread_num = thread_num
         self.config = config
         self.request = request

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -79,7 +79,7 @@ class MultiPlotQueryGenerator(AbstractQueryGenerator):
         return result
 
 
-class SearchQuery(AbstractQueryGenerator):
+class SearchQueryGenerator(AbstractQueryGenerator):
     query_interval_name = 'search_query_weight'
 
     def generate_metrics_regex(self):

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -48,7 +48,7 @@ class SinglePlotQueryGenerator(AbstractQueryGenerator):
         return result
 
 
-class MultiPlotQuery(AbstractQueryGenerator):
+class MultiPlotQueryGenerator(AbstractQueryGenerator):
     query_interval_name = 'multiplot_query_weight'
 
     def generate_multiplot_payload(self):

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -13,7 +13,7 @@ except ImportError:
     from nvpair import NVPair
 
 
-class AbstractQuery(AbstractGenerator):
+class AbstractQueryGenerator(AbstractGenerator):
     one_day = (1000 * 60 * 60 * 24)
 
     query_interval_name = None
@@ -26,7 +26,7 @@ class AbstractQuery(AbstractGenerator):
         self.request = request
 
 
-class SinglePlotQuery(AbstractQuery):
+class SinglePlotQuery(AbstractQueryGenerator):
     query_interval_name = 'singleplot_query_weight'
 
     def make_request(self, logger, time, tenant_id=None,
@@ -48,7 +48,7 @@ class SinglePlotQuery(AbstractQuery):
         return result
 
 
-class MultiPlotQuery(AbstractQuery):
+class MultiPlotQuery(AbstractQueryGenerator):
     query_interval_name = 'multiplot_query_weight'
 
     def generate_multiplot_payload(self):
@@ -79,7 +79,7 @@ class MultiPlotQuery(AbstractQuery):
         return result
 
 
-class SearchQuery(AbstractQuery):
+class SearchQuery(AbstractQueryGenerator):
     query_interval_name = 'search_query_weight'
 
     def generate_metrics_regex(self):
@@ -101,7 +101,7 @@ class SearchQuery(AbstractQuery):
         return result
 
 
-class AnnotationsQuery(AbstractQuery):
+class AnnotationsQuery(AbstractQueryGenerator):
     query_interval_name = 'annotations_query_weight'
 
     def make_request(self, logger, time, tenant_id=None):

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -109,7 +109,7 @@ class FakeIdentityConnector(object):
                         'id': UserTest.tenant}}}})
 
 requests_by_type = {
-    ingest.IngestThread:                        MockReq(),
+    ingest.IngestGenerator:                        MockReq(),
     annotationsingest.AnnotationsIngestThread:  MockReq(),
     query.SinglePlotQuery:                      MockReq(),
     query.MultiPlotQuery:                       MockReq(),
@@ -172,103 +172,103 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_0(self):
         th = self.tm.setup_thread(0, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_1(self):
         th = self.tm.setup_thread(1, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_2(self):
         th = self.tm.setup_thread(2, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_3(self):
         th = self.tm.setup_thread(3, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_4(self):
         th = self.tm.setup_thread(4, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_5(self):
         th = self.tm.setup_thread(5, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_6(self):
         th = self.tm.setup_thread(6, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_7(self):
         th = self.tm.setup_thread(7, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_8(self):
         th = self.tm.setup_thread(8, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_9(self):
         th = self.tm.setup_thread(9, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_10(self):
         th = self.tm.setup_thread(10, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_11(self):
         th = self.tm.setup_thread(11, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_12(self):
         th = self.tm.setup_thread(12, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_13(self):
         th = self.tm.setup_thread(13, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_14(self):
         th = self.tm.setup_thread(14, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_15(self):
         th = self.tm.setup_thread(15, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_16(self):
         th = self.tm.setup_thread(16, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_17(self):
         th = self.tm.setup_thread(17, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_18(self):
         th = self.tm.setup_thread(18, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_19(self):
         th = self.tm.setup_thread(19, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_20(self):
         th = self.tm.setup_thread(20, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_21(self):
         th = self.tm.setup_thread(21, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_22(self):
         th = self.tm.setup_thread(22, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_23(self):
         th = self.tm.setup_thread(23, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_24(self):
         th = self.tm.setup_thread(24, 0)
-        self.assertEqual(type(th), ingest.IngestThread)
+        self.assertEqual(type(th), ingest.IngestGenerator)
 
     def test_thread_type_assignment_25(self):
         th = self.tm.setup_thread(25, 0)
@@ -406,7 +406,7 @@ class GeneratePayloadTest(TestCaseBase):
 
     def test_generate_payload(self):
         agent_num = 1
-        thread = ingest.IngestThread(0, agent_num, MockReq(), self.test_config)
+        thread = ingest.IngestGenerator(0, agent_num, MockReq(), self.test_config)
         payload = json.loads(
             thread.generate_payload(0, [[2, 3, 0], [2, 4, 0], [2, 5, 0]]))
         valid_payload = [{'collectionTime': 0,
@@ -521,7 +521,7 @@ class MakeIngestRequestsTest(TestCaseBase):
     def test_ingest_make_request(self):
         global sleep_time
         agent_num = 0
-        thread = ingest.IngestThread(0, agent_num, MockReq(), self.test_config)
+        thread = ingest.IngestGenerator(0, agent_num, MockReq(), self.test_config)
         valid_payload = [
             {"collectionTime": 1000, "ttlInSeconds": 172800, "tenantId": "2",
              "metricValue": 0, "unit": "days",
@@ -628,7 +628,7 @@ class ThrottlingGroupTest(unittest.TestCase):
                                  time_source=time_source)
         treq = ThrottlingRequest(tgroup, MockReq())
         test_config = abstract_thread.default_config.copy()
-        th1 = ingest.IngestThread(0, 0, treq, test_config)
+        th1 = ingest.IngestGenerator(0, 0, treq, test_config)
 
         # when
         th1.make_request(pp, 1000)
@@ -716,7 +716,7 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
         tgroup = ThrottlingGroup('test', 6, time_source, sleep_source)
         treq = ThrottlingRequest(tgroup, MockReq())
 
-        th1 = ingest.IngestThread(0, 0, treq, self.test_config)
+        th1 = ingest.IngestGenerator(0, 0, treq, self.test_config)
         th2 = annotationsingest.AnnotationsIngestThread(
             1, 0, treq, self.test_config)
         th3 = query.SinglePlotQuery(2, 0, treq, self.test_config)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -110,7 +110,7 @@ class FakeIdentityConnector(object):
 
 requests_by_type = {
     ingest.IngestGenerator:                        MockReq(),
-    annotationsingest.AnnotationsIngestThread:  MockReq(),
+    annotationsingest.AnnotationsIngestGenerator:  MockReq(),
     query.SinglePlotQuery:                      MockReq(),
     query.MultiPlotQuery:                       MockReq(),
     query.SearchQuery:                          MockReq(),
@@ -272,39 +272,39 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_25(self):
         th = self.tm.setup_thread(25, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_26(self):
         th = self.tm.setup_thread(26, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_27(self):
         th = self.tm.setup_thread(27, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_28(self):
         th = self.tm.setup_thread(28, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_29(self):
         th = self.tm.setup_thread(29, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_30(self):
         th = self.tm.setup_thread(30, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_31(self):
         th = self.tm.setup_thread(31, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_32(self):
         th = self.tm.setup_thread(32, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_33(self):
         th = self.tm.setup_thread(33, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestThread)
+        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_34(self):
         th = self.tm.setup_thread(34, 0)
@@ -431,7 +431,7 @@ class GeneratePayloadTest(TestCaseBase):
 
     def test_generate_annotations_payload(self):
         agent_num = 1
-        thread = annotationsingest.AnnotationsIngestThread(
+        thread = annotationsingest.AnnotationsIngestGenerator(
             0, agent_num, MockReq(), self.test_config)
         payload = json.loads(thread.generate_payload(0, 3))
         valid_payload = {
@@ -472,7 +472,7 @@ class MakeAnnotationsIngestRequestsTest(TestCaseBase):
     def test_annotationsingest_make_request(self):
         global sleep_time
         agent_num = 0
-        thread = annotationsingest.AnnotationsIngestThread(
+        thread = annotationsingest.AnnotationsIngestGenerator(
             0, agent_num, MockReq(), self.test_config)
         tenant_id = 'tenantId'
         expected_url = (
@@ -717,7 +717,7 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
         treq = ThrottlingRequest(tgroup, MockReq())
 
         th1 = ingest.IngestGenerator(0, 0, treq, self.test_config)
-        th2 = annotationsingest.AnnotationsIngestThread(
+        th2 = annotationsingest.AnnotationsIngestGenerator(
             1, 0, treq, self.test_config)
         th3 = query.SinglePlotQuery(2, 0, treq, self.test_config)
         th4 = query.MultiPlotQuery(3, 0, treq, self.test_config)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -111,10 +111,10 @@ class FakeIdentityConnector(object):
 requests_by_type = {
     ingest.IngestGenerator:                        MockReq(),
     annotationsingest.AnnotationsIngestGenerator:  MockReq(),
-    query.SinglePlotQueryGenerator:                      MockReq(),
-    query.MultiPlotQueryGenerator:                       MockReq(),
-    query.SearchQueryGenerator:                          MockReq(),
-    query.AnnotationsQueryGenerator:                     MockReq(),
+    query.SinglePlotQueryGenerator:                MockReq(),
+    query.MultiPlotQueryGenerator:                 MockReq(),
+    query.SearchQueryGenerator:                    MockReq(),
+    query.AnnotationsQueryGenerator:               MockReq(),
 }
 
 

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -114,7 +114,7 @@ requests_by_type = {
     query.SinglePlotQueryGenerator:                      MockReq(),
     query.MultiPlotQueryGenerator:                       MockReq(),
     query.SearchQueryGenerator:                          MockReq(),
-    query.AnnotationsQuery:                     MockReq(),
+    query.AnnotationsQueryGenerator:                     MockReq(),
 }
 
 
@@ -348,7 +348,7 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_44(self):
         th = self.tm.setup_thread(44, 0)
-        self.assertEqual(type(th), query.AnnotationsQuery)
+        self.assertEqual(type(th), query.AnnotationsQueryGenerator)
 
     def test_setup_thread_invalid_thread_type(self):
         self.assertRaises(Exception, self.tm.setup_thread, (45, 0))
@@ -593,8 +593,8 @@ class MakeQueryRequestsTest(TestCaseBase):
         self.assertIs(req, response.request)
 
     def test_query_make_AnnotationsQuery_request(self):
-        req = requests_by_type[query.AnnotationsQuery]
-        qq = query.AnnotationsQuery(0, self.agent_num, req, self.config)
+        req = requests_by_type[query.AnnotationsQueryGenerator]
+        qq = query.AnnotationsQueryGenerator(0, self.agent_num, req, self.config)
         response = qq.make_request(None, 1000, 30)
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/30/events/" +
@@ -722,7 +722,7 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
         th3 = query.SinglePlotQueryGenerator(2, 0, treq, self.test_config)
         th4 = query.MultiPlotQueryGenerator(3, 0, treq, self.test_config)
         th5 = query.SearchQueryGenerator(4, 0, treq, self.test_config)
-        th6 = query.AnnotationsQuery(5, 0, treq, self.test_config)
+        th6 = query.AnnotationsQueryGenerator(5, 0, treq, self.test_config)
 
         # when
         th1.make_request(pp, 1000)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -111,7 +111,7 @@ class FakeIdentityConnector(object):
 requests_by_type = {
     ingest.IngestGenerator:                        MockReq(),
     annotationsingest.AnnotationsIngestGenerator:  MockReq(),
-    query.SinglePlotQuery:                      MockReq(),
+    query.SinglePlotQueryGenerator:                      MockReq(),
     query.MultiPlotQuery:                       MockReq(),
     query.SearchQuery:                          MockReq(),
     query.AnnotationsQuery:                     MockReq(),
@@ -308,15 +308,15 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_34(self):
         th = self.tm.setup_thread(34, 0)
-        self.assertEqual(type(th), query.SinglePlotQuery)
+        self.assertEqual(type(th), query.SinglePlotQueryGenerator)
 
     def test_thread_type_assignment_35(self):
         th = self.tm.setup_thread(35, 0)
-        self.assertEqual(type(th), query.SinglePlotQuery)
+        self.assertEqual(type(th), query.SinglePlotQueryGenerator)
 
     def test_thread_type_assignment_36(self):
         th = self.tm.setup_thread(36, 0)
-        self.assertEqual(type(th), query.SinglePlotQuery)
+        self.assertEqual(type(th), query.SinglePlotQueryGenerator)
 
     def test_thread_type_assignment_37(self):
         th = self.tm.setup_thread(37, 0)
@@ -552,8 +552,8 @@ class MakeQueryRequestsTest(TestCaseBase):
         self.requests_by_type = requests_by_type.copy()
 
     def test_query_make_SinglePlotQuery_request(self):
-        req = requests_by_type[query.SinglePlotQuery]
-        qq = query.SinglePlotQuery(0, self.agent_num, req, self.config)
+        req = requests_by_type[query.SinglePlotQueryGenerator]
+        qq = query.SinglePlotQueryGenerator(0, self.agent_num, req, self.config)
         response = qq.make_request(None, 1000, 0, 'org.example.metric.metric123')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/0/views/" +
@@ -719,7 +719,7 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
         th1 = ingest.IngestGenerator(0, 0, treq, self.test_config)
         th2 = annotationsingest.AnnotationsIngestGenerator(
             1, 0, treq, self.test_config)
-        th3 = query.SinglePlotQuery(2, 0, treq, self.test_config)
+        th3 = query.SinglePlotQueryGenerator(2, 0, treq, self.test_config)
         th4 = query.MultiPlotQuery(3, 0, treq, self.test_config)
         th5 = query.SearchQuery(4, 0, treq, self.test_config)
         th6 = query.AnnotationsQuery(5, 0, treq, self.test_config)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -272,39 +272,48 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_25(self):
         th = self.tm.setup_thread(25, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_26(self):
         th = self.tm.setup_thread(26, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_27(self):
         th = self.tm.setup_thread(27, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_28(self):
         th = self.tm.setup_thread(28, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_29(self):
         th = self.tm.setup_thread(29, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_30(self):
         th = self.tm.setup_thread(30, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_31(self):
         th = self.tm.setup_thread(31, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_32(self):
         th = self.tm.setup_thread(32, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_33(self):
         th = self.tm.setup_thread(33, 0)
-        self.assertEqual(type(th), annotationsingest.AnnotationsIngestGenerator)
+        self.assertEqual(type(th),
+                         annotationsingest.AnnotationsIngestGenerator)
 
     def test_thread_type_assignment_34(self):
         th = self.tm.setup_thread(34, 0)
@@ -406,7 +415,8 @@ class GeneratePayloadTest(TestCaseBase):
 
     def test_generate_payload(self):
         agent_num = 1
-        thread = ingest.IngestGenerator(0, agent_num, MockReq(), self.test_config)
+        thread = ingest.IngestGenerator(0, agent_num, MockReq(),
+                                        self.test_config)
         payload = json.loads(
             thread.generate_payload(0, [[2, 3, 0], [2, 4, 0], [2, 5, 0]]))
         valid_payload = [{'collectionTime': 0,
@@ -521,7 +531,8 @@ class MakeIngestRequestsTest(TestCaseBase):
     def test_ingest_make_request(self):
         global sleep_time
         agent_num = 0
-        thread = ingest.IngestGenerator(0, agent_num, MockReq(), self.test_config)
+        thread = ingest.IngestGenerator(0, agent_num, MockReq(),
+                                        self.test_config)
         valid_payload = [
             {"collectionTime": 1000, "ttlInSeconds": 172800, "tenantId": "2",
              "metricValue": 0, "unit": "days",
@@ -553,8 +564,10 @@ class MakeQueryRequestsTest(TestCaseBase):
 
     def test_query_make_SinglePlotQuery_request(self):
         req = requests_by_type[query.SinglePlotQueryGenerator]
-        qq = query.SinglePlotQueryGenerator(0, self.agent_num, req, self.config)
-        response = qq.make_request(None, 1000, 0, 'org.example.metric.metric123')
+        qq = query.SinglePlotQueryGenerator(0, self.agent_num, req,
+                                            self.config)
+        response = qq.make_request(None, 1000, 0,
+                                   'org.example.metric.metric123')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/0/views/" +
                          "org.example.metric.metric123?from=-86399000&" +
@@ -594,7 +607,8 @@ class MakeQueryRequestsTest(TestCaseBase):
 
     def test_query_make_AnnotationsQuery_request(self):
         req = requests_by_type[query.AnnotationsQueryGenerator]
-        qq = query.AnnotationsQueryGenerator(0, self.agent_num, req, self.config)
+        qq = query.AnnotationsQueryGenerator(0, self.agent_num, req,
+                                             self.config)
         response = qq.make_request(None, 1000, 30)
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/30/events/" +
@@ -994,7 +1008,6 @@ class ConnectorTest(TestCaseBase):
         resp = conn.post('http://httpbin.org/post', {}, [])
         jsonified = resp.json()
         self.assertEqual('{}', jsonified['data'])
-
 
 
 suite = unittest.TestSuite()

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -112,7 +112,7 @@ requests_by_type = {
     ingest.IngestGenerator:                        MockReq(),
     annotationsingest.AnnotationsIngestGenerator:  MockReq(),
     query.SinglePlotQueryGenerator:                      MockReq(),
-    query.MultiPlotQuery:                       MockReq(),
+    query.MultiPlotQueryGenerator:                       MockReq(),
     query.SearchQuery:                          MockReq(),
     query.AnnotationsQuery:                     MockReq(),
 }
@@ -320,15 +320,15 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_37(self):
         th = self.tm.setup_thread(37, 0)
-        self.assertEqual(type(th), query.MultiPlotQuery)
+        self.assertEqual(type(th), query.MultiPlotQueryGenerator)
 
     def test_thread_type_assignment_38(self):
         th = self.tm.setup_thread(38, 0)
-        self.assertEqual(type(th), query.MultiPlotQuery)
+        self.assertEqual(type(th), query.MultiPlotQueryGenerator)
 
     def test_thread_type_assignment_39(self):
         th = self.tm.setup_thread(39, 0)
-        self.assertEqual(type(th), query.MultiPlotQuery)
+        self.assertEqual(type(th), query.MultiPlotQueryGenerator)
 
     def test_thread_type_assignment_40(self):
         th = self.tm.setup_thread(40, 0)
@@ -571,8 +571,8 @@ class MakeQueryRequestsTest(TestCaseBase):
         self.assertIs(req, response.request)
 
     def test_query_make_MultiPlotQuery_request(self):
-        req = requests_by_type[query.MultiPlotQuery]
-        qq = query.MultiPlotQuery(0, self.agent_num, req, self.config)
+        req = requests_by_type[query.MultiPlotQueryGenerator]
+        qq = query.MultiPlotQueryGenerator(0, self.agent_num, req, self.config)
         payload_sent = json.dumps([
             "org.example.metric.0",
             "org.example.metric.1",
@@ -720,7 +720,7 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
         th2 = annotationsingest.AnnotationsIngestGenerator(
             1, 0, treq, self.test_config)
         th3 = query.SinglePlotQueryGenerator(2, 0, treq, self.test_config)
-        th4 = query.MultiPlotQuery(3, 0, treq, self.test_config)
+        th4 = query.MultiPlotQueryGenerator(3, 0, treq, self.test_config)
         th5 = query.SearchQuery(4, 0, treq, self.test_config)
         th6 = query.AnnotationsQuery(5, 0, treq, self.test_config)
 

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -113,7 +113,7 @@ requests_by_type = {
     annotationsingest.AnnotationsIngestGenerator:  MockReq(),
     query.SinglePlotQueryGenerator:                      MockReq(),
     query.MultiPlotQueryGenerator:                       MockReq(),
-    query.SearchQuery:                          MockReq(),
+    query.SearchQueryGenerator:                          MockReq(),
     query.AnnotationsQuery:                     MockReq(),
 }
 
@@ -332,19 +332,19 @@ class ThreadManagerTest(TestCaseBase):
 
     def test_thread_type_assignment_40(self):
         th = self.tm.setup_thread(40, 0)
-        self.assertEqual(type(th), query.SearchQuery)
+        self.assertEqual(type(th), query.SearchQueryGenerator)
 
     def test_thread_type_assignment_41(self):
         th = self.tm.setup_thread(41, 0)
-        self.assertEqual(type(th), query.SearchQuery)
+        self.assertEqual(type(th), query.SearchQueryGenerator)
 
     def test_thread_type_assignment_42(self):
         th = self.tm.setup_thread(42, 0)
-        self.assertEqual(type(th), query.SearchQuery)
+        self.assertEqual(type(th), query.SearchQueryGenerator)
 
     def test_thread_type_assignment_43(self):
         th = self.tm.setup_thread(43, 0)
-        self.assertEqual(type(th), query.SearchQuery)
+        self.assertEqual(type(th), query.SearchQueryGenerator)
 
     def test_thread_type_assignment_44(self):
         th = self.tm.setup_thread(44, 0)
@@ -562,8 +562,8 @@ class MakeQueryRequestsTest(TestCaseBase):
         self.assertIs(req, response.request)
 
     def test_query_make_SearchQuery_request(self):
-        req = requests_by_type[query.SearchQuery]
-        qq = query.SearchQuery(0, self.agent_num, req, self.config)
+        req = requests_by_type[query.SearchQueryGenerator]
+        qq = query.SearchQueryGenerator(0, self.agent_num, req, self.config)
         response = qq.make_request(None, 1000, 10, 'org.example.metric.*')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/10/metrics/search?" +
@@ -721,7 +721,7 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
             1, 0, treq, self.test_config)
         th3 = query.SinglePlotQueryGenerator(2, 0, treq, self.test_config)
         th4 = query.MultiPlotQueryGenerator(3, 0, treq, self.test_config)
-        th5 = query.SearchQuery(4, 0, treq, self.test_config)
+        th5 = query.SearchQueryGenerator(4, 0, treq, self.test_config)
         th6 = query.AnnotationsQuery(5, 0, treq, self.test_config)
 
         # when

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -5,8 +5,8 @@ import ast
 from abstract_thread import default_config
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQueryGenerator
-from query import AnnotationsQueryGenerator
+from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator
+from query import SearchQueryGenerator, AnnotationsQueryGenerator
 from config import clean_configs, convert
 
 
@@ -61,7 +61,8 @@ class ThreadManager(object):
              self.config.get('multiplot_query_throttling_group', None)),
             (SearchQueryGenerator, self.config['search_query_weight'],
              self.config.get('search_query_throttling_group', None)),
-            (AnnotationsQueryGenerator, self.config['annotations_query_weight'],
+            (AnnotationsQueryGenerator,
+             self.config['annotations_query_weight'],
              self.config.get('annotations_query_throttling_group', None)),
         ]
 

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -5,7 +5,7 @@ import ast
 from abstract_thread import default_config
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQueryGenerator, MultiPlotQuery, SearchQuery
+from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs, convert
 
@@ -57,8 +57,8 @@ class ThreadManager(object):
              self.config.get('annotations_throttling_group', None)),
             (SinglePlotQueryGenerator, self.config['singleplot_query_weight'],
              self.config.get('singleplot_query_throttling_group', None)),
-            (MultiPlotQuery, self.config['multiplot_query_weight'],
-                self.config.get('multiplot_query_throttling_group', None)),
+            (MultiPlotQueryGenerator, self.config['multiplot_query_weight'],
+             self.config.get('multiplot_query_throttling_group', None)),
             (SearchQuery, self.config['search_query_weight'],
                 self.config.get('search_query_throttling_group', None)),
             (AnnotationsQuery, self.config['annotations_query_weight'],

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -3,7 +3,7 @@
 import ast
 
 from abstract_thread import default_config
-from annotationsingest import AnnotationsIngestThread
+from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
 from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
@@ -53,8 +53,8 @@ class ThreadManager(object):
         thread_types = [
             (IngestGenerator, self.config['ingest_weight'],
              self.config.get('ingest_throttling_group', None)),
-            (AnnotationsIngestThread, self.config['annotations_weight'],
-                self.config.get('annotations_throttling_group', None)),
+            (AnnotationsIngestGenerator, self.config['annotations_weight'],
+             self.config.get('annotations_throttling_group', None)),
             (SinglePlotQuery, self.config['singleplot_query_weight'],
                 self.config.get('singleplot_query_throttling_group', None)),
             (MultiPlotQuery, self.config['multiplot_query_weight'],

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -6,7 +6,7 @@ from abstract_thread import default_config
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
 from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQueryGenerator
-from query import AnnotationsQuery
+from query import AnnotationsQueryGenerator
 from config import clean_configs, convert
 
 
@@ -61,8 +61,8 @@ class ThreadManager(object):
              self.config.get('multiplot_query_throttling_group', None)),
             (SearchQueryGenerator, self.config['search_query_weight'],
              self.config.get('search_query_throttling_group', None)),
-            (AnnotationsQuery, self.config['annotations_query_weight'],
-                self.config.get('annotations_query_throttling_group', None)),
+            (AnnotationsQueryGenerator, self.config['annotations_query_weight'],
+             self.config.get('annotations_query_throttling_group', None)),
         ]
 
         total_weight = 0

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -5,7 +5,7 @@ import ast
 from abstract_thread import default_config
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
+from query import SinglePlotQueryGenerator, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs, convert
 
@@ -55,8 +55,8 @@ class ThreadManager(object):
              self.config.get('ingest_throttling_group', None)),
             (AnnotationsIngestGenerator, self.config['annotations_weight'],
              self.config.get('annotations_throttling_group', None)),
-            (SinglePlotQuery, self.config['singleplot_query_weight'],
-                self.config.get('singleplot_query_throttling_group', None)),
+            (SinglePlotQueryGenerator, self.config['singleplot_query_weight'],
+             self.config.get('singleplot_query_throttling_group', None)),
             (MultiPlotQuery, self.config['multiplot_query_weight'],
                 self.config.get('multiplot_query_throttling_group', None)),
             (SearchQuery, self.config['search_query_weight'],

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -4,7 +4,7 @@ import ast
 
 from abstract_thread import default_config
 from annotationsingest import AnnotationsIngestThread
-from ingest import IngestThread
+from ingest import IngestGenerator
 from query import SinglePlotQuery, MultiPlotQuery, SearchQuery
 from query import AnnotationsQuery
 from config import clean_configs, convert
@@ -51,8 +51,8 @@ class ThreadManager(object):
         thread_type = None
 
         thread_types = [
-            (IngestThread, self.config['ingest_weight'],
-                self.config.get('ingest_throttling_group', None)),
+            (IngestGenerator, self.config['ingest_weight'],
+             self.config.get('ingest_throttling_group', None)),
             (AnnotationsIngestThread, self.config['annotations_weight'],
                 self.config.get('annotations_throttling_group', None)),
             (SinglePlotQuery, self.config['singleplot_query_weight'],

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -5,7 +5,7 @@ import ast
 from abstract_thread import default_config
 from annotationsingest import AnnotationsIngestGenerator
 from ingest import IngestGenerator
-from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQuery
+from query import SinglePlotQueryGenerator, MultiPlotQueryGenerator, SearchQueryGenerator
 from query import AnnotationsQuery
 from config import clean_configs, convert
 
@@ -59,8 +59,8 @@ class ThreadManager(object):
              self.config.get('singleplot_query_throttling_group', None)),
             (MultiPlotQueryGenerator, self.config['multiplot_query_weight'],
              self.config.get('multiplot_query_throttling_group', None)),
-            (SearchQuery, self.config['search_query_weight'],
-                self.config.get('search_query_throttling_group', None)),
+            (SearchQueryGenerator, self.config['search_query_weight'],
+             self.config.get('search_query_throttling_group', None)),
             (AnnotationsQuery, self.config['annotations_query_weight'],
                 self.config.get('annotations_query_throttling_group', None)),
         ]


### PR DESCRIPTION
This PR renames the `*Thread` classes to `*Generator`, to better reflect the actual purpose of the classes as load generators. The process has been divided into two other PR's which will be opened after this one is merged. This is just a rename/refactoring, with no changes to functionality. After the refactoring, all unit tests still passed and the code ran correctly in QE02 for five days with zero errors.