### PR TITLE
Log 5xx responses

### DIFF
--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -48,10 +48,4 @@ class AnnotationsIngestGenerator(AbstractGenerator):
 
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
-        if result.getStatusCode() >= 400:
-            logger("Error: status code=" + str(result.getStatusCode()) +
-                   " req url=" + url +
-                   " req headers=" + str(headers) +
-                   " req payload=" + payload +
-                   " resp payload=" + result.getText())
         return result

--- a/scripts/error_logging_request.py
+++ b/scripts/error_logging_request.py
@@ -2,7 +2,7 @@
 
 class ErrorLoggingRequest():
 
-    """This request write to the grinder log all error responses with a 
+    """This request write to the grinder log all error responses with a
     status code of 5XX."""
 
     def __init__(self, request, log):
@@ -12,12 +12,15 @@ class ErrorLoggingRequest():
     def wrap(self, callee):
         response = callee()
         if response.getStatusCode() >= 500:
-            s = '\n    %s %s %s\n' % (response.getVersion(), response.getStatusCode(),
-                                response.getReasonLine())
+            s = '\n    %s %s %s\n' % (response.getVersion(),
+                                      response.getStatusCode(),
+                                      response.getReasonLine())
+
             def clean(s):
                 return s.replace('\n', '\n    ')
             for header in response.listHeaders():
-                s += '    %s: %s\n' % (header, clean(response.getHeader(header)))
+                s += '    %s: %s\n' % (header,
+                                       clean(response.getHeader(header)))
             text = response.getText()
             if text:
                 s += '\n    '

--- a/scripts/error_logging_request.py
+++ b/scripts/error_logging_request.py
@@ -12,7 +12,17 @@ class ErrorLoggingRequest():
     def wrap(self, callee):
         response = callee()
         if response.getStatusCode() >= 500:
-            self.log(response)
+            s = '\n    %s %s %s\n' % (response.getVersion(), response.getStatusCode(),
+                                response.getReasonLine())
+            def clean(s):
+                return s.replace('\n', '\n    ')
+            for header in response.listHeaders():
+                s += '    %s: %s\n' % (header, clean(response.getHeader(header)))
+            text = response.getText()
+            if text:
+                s += '\n    '
+                s += clean(text)
+            self.log(s)
         return response
 
     def GET(self, *args, **kwargs):

--- a/scripts/error_logging_request.py
+++ b/scripts/error_logging_request.py
@@ -11,7 +11,7 @@ class ErrorLoggingRequest():
 
     def wrap(self, callee):
         response = callee()
-        if response.getStatusCode() >= 500:
+        if response.getStatusCode() >= 400:
             s = '\n    %s %s %s\n' % (response.getVersion(),
                                       response.getStatusCode(),
                                       response.getReasonLine())

--- a/scripts/error_logging_request.py
+++ b/scripts/error_logging_request.py
@@ -1,0 +1,37 @@
+
+
+class ErrorLoggingRequest():
+
+    """This request write to the grinder log all error responses with a 
+    status code of 5XX."""
+
+    def __init__(self, request, log):
+        self.request = request
+        self.log = log
+
+    def wrap(self, callee):
+        response = callee()
+        if response.getStatusCode() >= 500:
+            self.log(response)
+        return response
+
+    def GET(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.GET(*args, **kwargs))
+
+    def HEAD(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.HEAD(*args, **kwargs))
+
+    def POST(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.POST(*args, **kwargs))
+
+    def PUT(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.PUT(*args, **kwargs))
+
+    def DELETE(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.DELETE(*args, **kwargs))
+
+    def OPTIONS(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.OPTIONS(*args, **kwargs))
+
+    def TRACE(self, *args, **kwargs):
+        return self.wrap(lambda: self.request.TRACE(*args, **kwargs))

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -20,6 +20,7 @@ from authenticating_request import AuthenticatingRequest
 from response_checking_request import ResponseCheckingRequest
 from exception_handling_request import ExceptionHandlingRequest
 from get_user import get_user
+from error_logging_request import ErrorLoggingRequest
 
 # ENTRY POINT into the Grinder
 
@@ -63,6 +64,7 @@ def create_request_obj(test_num, test_name, tgroup_name=None,
     request = ResponseCheckingRequest(request)
     test.record(request)
     request = ExceptionHandlingRequest(request)
+    request = ErrorLoggingRequest(request, grinder.logger.info)
     if auth_user:
         grinder.logger.debug('%s request object will authenticate with '
                             'username "%s".' % (test_name, auth_user.username))

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -87,8 +87,6 @@ class IngestGenerator(AbstractGenerator):
         headers = ( NVPair("Content-Type", "application/json"), )
         url = self.ingest_url()
         result = self.request.POST(url, payload, headers)
-        if result.getStatusCode() >= 400:
-            logger("IngestGenerator Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         if 200 <= result.getStatusCode() < 300:
             self.count_raw_metrics(len(tenant_metric_id_values))
         return result

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -74,8 +74,6 @@ class MultiPlotQueryGenerator(AbstractQueryGenerator):
             to, resolution)
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
-        if result.getStatusCode() >= 400:
-            logger("MultiPlotQuery Error: status code=" + str(result.getStatusCode()) + " response=" + result.getText())
         return result
 
 


### PR DESCRIPTION
This PR adds an `ErrorLoggingRequest` class that writes 5XX responses to the log file. This will work on every request type (ingest, search , etc). The request-type-specific logging that we had been doing in an ad-hoc fashion has been removed.