### PR TITLE
make "example" properties create more load

### DIFF
--- a/properties/grinder-local.properties
+++ b/properties/grinder-local.properties
@@ -1,21 +1,32 @@
+# A sample properties file that will send a fair amount of load to Blueflood when run on a single agent. It'll ingest
+# about a hundred tenants, a hundred unique metric names per tenant, and 300,000 individual data points in all (if my
+# math and understanding of these settings are correct).
+
 grinder.script=../scripts/grinder.py
+# I don't think this path does anything.
 grinder.package_path=/Library/Python/2.7/site-packages
-grinder.runs=1
-grinder.threads=95
+# One run means each thread makes a single request, which isn't too helpful. Let's start with a decent workload of 100.
+grinder.runs=100
+# All weights below add up to 60, so let's do 60 threads; therefore weight == number of threads.
+grinder.threads=60
 grinder.useConsole=true
 grinder.consoleHost = 127.0.0.1
 grinder.logDirectory=resources/logs
 
+# Make sure these point to ingest and query ports, respectively, of a running Blueflood.
 grinder.bf.url="http://localhost:19000"
 grinder.bf.query_url="http://localhost:20000"
 
 grinder.bf.max_multiplot_metrics=10
-grinder.bf.name_fmt="org.example.metric.%d"
+# Make metric names sufficiently long. Real names have lots of tokens in them.
+grinder.bf.name_fmt="org.example.metric.entity.en12345678.check.ch12345678.some_named_thing.%d"
 
 grinder.bf.ingest_weight=15
-grinder.bf.ingest_num_tenants=4
-grinder.bf.ingest_metrics_per_tenant=15
-grinder.bf.ingest_batch_size=5
+# 100 different tenants and metrics should provide an observable amount of load in terms of number of things to ingest.
+grinder.bf.ingest_num_tenants=100
+grinder.bf.ingest_metrics_per_tenant=100
+# I think metrics regularly arrive in batches of a hundred or more in production.
+grinder.bf.ingest_batch_size=200
 
 grinder.bf.annotations_weight=5
 grinder.bf.annotations_num_tenants=4


### PR DESCRIPTION
When I first came to this project, I assumed the example properties
file was set to create some decent load. It isn't. Through running it,
reading the code, and examining Blueflood performance charts that
result from running it, I realized that the existing settings are
extremely low in terms of load. This updates them to be more like what
you'd expect from a "performance" or "load test" project. Instead of
generating tens of data points for a few tenants, now it'll generate
hundreds of thosands of them for a hundred tenants.