### PR TITLE
generate metrics for more than one tenant

### DIFF
--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -29,7 +29,10 @@ class AnnotationsIngestGenerator(AbstractGenerator):
 
     def ingest_url(self, tenant_id=None):
         if tenant_id is None:
-            tenant_id = self.user.get_tenant_id()
+            if self.user.is_real_user():
+                tenant_id = self.user.get_tenant_id()
+            else:
+                tenant_id = random.randint(0, self.config['annotations_num_tenants'])
         return "%s/v2.0/%s/events" % (self.config['url'], tenant_id)
 
     def make_request(self, logger, time, tenant_and_metric=None):

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -69,6 +69,8 @@ class IngestGenerator(AbstractGenerator):
 
     def ingest_url(self, tenantId=None):
         if tenantId is None:
+            # The ingest/multi endpoint takes the tenant from each metric. The URL tenant is only used for
+            # authorization.
             tenantId = self.user.get_tenant_id()
         return "%s/v2.0/%s/ingest/multi" % (self.config['url'], str(tenantId))
 
@@ -76,7 +78,10 @@ class IngestGenerator(AbstractGenerator):
         if tenant_metric_id_values is None:
             tenant_metric_id_values = []
             for i in xrange(self.config['ingest_batch_size']):
-                tenant_id = self.user.get_tenant_id()
+                if self.user.is_real_user():
+                    tenant_id = self.user.get_tenant_id()
+                else:
+                    tenant_id = random.randint(0, self.config['ingest_num_tenants'])
                 metric_id = random.randint(
                     1, self.config['ingest_metrics_per_tenant'])
                 value = random.randint(0, RAND_MAX)

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -32,7 +32,10 @@ class SinglePlotQueryGenerator(AbstractQueryGenerator):
     def make_request(self, logger, time, tenant_id=None,
                      metric_name=None):
         if tenant_id is None:
-            tenant_id = self.user.get_tenant_id()
+            if self.user.is_real_user():
+                tenant_id = self.user.get_tenant_id()
+            else:
+                tenant_id = random.randint(0, self.config['ingest_num_tenants'])
         if metric_name is None:
             metric_name = generate_metric_name(
                 random.randint(0, self.config['ingest_metrics_per_tenant']),
@@ -62,7 +65,10 @@ class MultiPlotQueryGenerator(AbstractQueryGenerator):
 
     def make_request(self, logger, time, tenant_id=None, payload=None):
         if tenant_id is None:
-            tenant_id = self.user.get_tenant_id()
+            if self.user.is_real_user():
+                tenant_id = self.user.get_tenant_id()
+            else:
+                tenant_id = random.randint(0, self.config['ingest_num_tenants'])
         if payload is None:
             payload = self.generate_multiplot_payload()
         to = time
@@ -89,7 +95,10 @@ class SearchQueryGenerator(AbstractQueryGenerator):
     def make_request(self, logger, time, tenant_id=None,
                      metric_regex=None):
         if tenant_id is None:
-            tenant_id = self.user.get_tenant_id()
+            if self.user.is_real_user():
+                tenant_id = self.user.get_tenant_id()
+            else:
+                tenant_id = random.randint(0, self.config['ingest_num_tenants'])
         if metric_regex is None:
             metric_regex = self.generate_metrics_regex()
         url = "%s/v2.0/%s/metrics/search?query=%s" % (
@@ -104,11 +113,13 @@ class AnnotationsQueryGenerator(AbstractQueryGenerator):
 
     def make_request(self, logger, time, tenant_id=None):
         if tenant_id is None:
-            tenant_id = self.user.get_tenant_id()
+            if self.user.is_real_user():
+                tenant_id = self.user.get_tenant_id()
+            else:
+                tenant_id = random.randint(0, self.config['annotations_num_tenants'])
         to = time
         frm = time - self.one_day
         url = "%s/v2.0/%s/events/getEvents?from=%d&until=%d" % (
             self.config['query_url'], tenant_id, frm, to)
         result = self.request.GET(url)
         return result
-

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -154,7 +154,7 @@ grinder_props = {
     'grinder.bf.max_multiplot_metrics': '10',
 
     'grinder.bf.ingest_weight': '15',
-    'grinder.bf.num_tenants': '4',
+    'grinder.bf.ingest_num_tenants': '4',
     'grinder.bf.metrics_per_tenant': '15',
     'grinder.bf.ingest_batch_size': '5',
 

--- a/scripts/user.py
+++ b/scripts/user.py
@@ -132,6 +132,9 @@ class User(object):
 
         return False
 
+    def is_real_user(self):
+        return True
+
 
 class NullUser(object):
     def get_token(self):
@@ -144,4 +147,7 @@ class NullUser(object):
         return self.get_tenant_id(), self.get_token()
 
     def is_expired(self):
+        return False
+
+    def is_real_user(self):
         return False


### PR DESCRIPTION
As originally written, this project would generate metrics for
multiple tenants, picking them at random. Some time more recently,
someone added the ability to authenticate a real user and use that
user's tenant id. In doing so, they made it so only one tenant id was
used *always*, even if not using a real user. This brings back the
code that randomizes the tenant id when *not* using a real user.