### PR TITLE
add property for /ingest vs /ingest/multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
   ingested. Example: `"0,0,0,60000"` would make about 1/4 of the metrics of even-numbered tenants appear delayed by 1
   minute.
 
+* `[grinder.bf.]ingest_use_multi_ingest` - Whether to call the `/ingest/multi` endpoint or the `/ingest` endpoint.
+  Default is `true`, meaning call `/ingest/multi`. That's useful for creating metrics for multiple tenants, but it
+  requires elevated privileges in staging and production. Setting this to `false` helps work around that.
+
 * `[grinder.bf.]ingest_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `IngestThread` objects. Default is `None`. If the tgroup name is blank, or is not defined among the throttling groups (or if there is a _spelling error_), then no throttling will be performed for this thread type.
 * `[grinder.bf.]ingest_count_raw_metrics` - `True` to create a secondary Grinder `Test` object to track the total number of metrics ingested, not just the number of HTTP requests. The count is increased by the number of metrics in a given POST payload (which should be equal to `ingest_batch_size`), when the given request is successful. Note that this will skew the total TPS and other statistics that Grinder collects. Default is False.
 

--- a/scripts/abstract_generator.py
+++ b/scripts/abstract_generator.py
@@ -18,6 +18,7 @@ default_config = {
     'ingest_num_tenants': 4,
     'ingest_metrics_per_tenant': 15,
     'ingest_batch_size': 5,
+    'ingest_use_multi_ingest': 'true',
     # ingest_delay_millis is comma separated list of delays used during
     # ingestion
     'ingest_delay_millis': "",

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -576,6 +576,35 @@ class MakeIngestRequestsTest(TestCaseBase):
             'http://metrics-ingest.example.org/v2.0/tenantId/ingest/multi')
         self.assertEqual(eval(payload), valid_payload)
 
+    def test_ingest_with_no_use_multi(self):
+        self.test_config['ingest_use_multi_ingest'] = 'false'
+        global sleep_time
+        agent_num = 0
+        generator = ingest.IngestGenerator(0, agent_num, MockReq(),
+                                           self.test_config)
+        tenant_metric_id_values = [
+            [2, 0, 0],
+            [2, 1, 0]
+        ]
+        response = generator.make_request(pp, 1000, tenant_metric_id_values)
+        url = response.request.post_url
+        payload = response.request.post_payload
+
+        # It should use the singular /ingest endpoint instead of /ingest/multi and not include a "tenantId" field in the
+        # payload.
+        self.assertEqual(
+            url,
+            'http://metrics-ingest.example.org/v2.0/tenantId/ingest')
+
+        valid_payload = [
+            {"collectionTime": 1000, "ttlInSeconds": 172800,
+             "metricValue": 0, "unit": "days",
+             "metricName": "org.example.metric.0"},
+            {"collectionTime": 1000, "ttlInSeconds": 172800,
+             "metricValue": 0, "unit": "days",
+             "metricName": "org.example.metric.1"}]
+        self.assertEqual(eval(payload), valid_payload)
+
 
 class MakeQueryRequestsTest(TestCaseBase):
     def setUp(self):


### PR DESCRIPTION
Generally, it would be best in a load test to ingest metrics for many tenants, but if the environment under test requires special permissions to use the /ingest/multi endpoint, it can get in the way. This is a simple way of working around that when necessary.