### PR TITLE
log whether user was authed or not

### DIFF
--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -69,6 +69,8 @@ def create_request_obj(test_num, test_name, tgroup_name=None,
         grinder.logger.debug('%s request object will authenticate with '
                             'username "%s".' % (test_name, auth_user.username))
         request = AuthenticatingRequest(request, auth_user)
+    else:
+        grinder.logger.debug('%s request object will not authenticate.' % test_name)
     if tgroup_name:
         grinder.logger.debug('%s request object will throttle with group '
                             '"%s".' % (test_name, tgroup_name))


### PR DESCRIPTION
When dealing with the tenant id and auth stuff, it wasn't clear to me at first when a user was authenticated or not.  It already logs when a user is authenticating. Adding a log to the opposite side helps be clear.