### PR TITLE
add flag to require non-empty queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]annotations_per_tenant` - Exactly like `ingest_metrics_per_tenant`, except that this property controls the number of metric name suffixes for the `AnnotationsIngestThread` class. This property is provided so that ingest threads can be configured independently. Default is `10`.
 * `[grinder.bf.]annotations_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `AnnotationsIngestThread` objects. Default is `None`. If the tgroup name is blank, or is not defined among the throttling groups (or if there is a _spelling error_), then no throttling will be performed for this thread type.
 
+* `[grinder.bf.]query_require_results` - Require a minimum number of results per query test. Default is `0`, meaning
+  don't require any results. This can be helpful to ensure queries aren't just returning success with an empty payload.
+
 * `[grinder.bf.]singleplot_query_weight` - Default is `10`.
 * `[grinder.bf.]singleplot_query_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `SinglePlotQuery` objects. Default is `None`. If the tgroup name is blank, or is not defined among the throttling groups (or if there is a _spelling error_), then no throttling will be performed for this thread type.
 

--- a/scripts/abstract_generator.py
+++ b/scripts/abstract_generator.py
@@ -26,6 +26,7 @@ default_config = {
     'annotations_num_tenants': 5,
     'annotations_per_tenant': 10,
 
+    'query_require_results': 0,
     'singleplot_query_weight': 10,
 
     'multiplot_query_weight': 10,

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -45,6 +45,14 @@ class SinglePlotQueryGenerator(AbstractQueryGenerator):
             tenant_id, metric_name, frm,
             to, resolution)
         result = self.request.GET(url)
+        # If we got zero results back, we don't really know if this was a successful test or not, but maybe we don't
+        # care, either...
+        min_results = self.config['query_require_results']
+        payload = json.loads(result.getText())
+        if len(payload) <= min_results:
+            raise Exception(
+                'Single plot query returned less than query_require_results; ' +
+                'consider reducing permutations or increasing ingest weight')
         return result
 
 
@@ -74,6 +82,12 @@ class MultiPlotQueryGenerator(AbstractQueryGenerator):
             to, resolution)
         headers = ( NVPair("Content-Type", "application/json"), )
         result = self.request.POST(url, payload, headers)
+        min_results = self.config['query_require_results']
+        payload = json.loads(result.getText())
+        if len(payload) <= min_results:
+            raise Exception(
+                'Multiplot query returned less than query_require_results; ' +
+                'consider reducing permutations or increasing ingest weight')
         return result
 
 
@@ -96,6 +110,12 @@ class SearchQueryGenerator(AbstractQueryGenerator):
             self.config['query_url'],
             tenant_id, metric_regex)
         result = self.request.GET(url)
+        min_results = self.config['query_require_results']
+        payload = json.loads(result.getText())
+        if len(payload) <= min_results:
+            raise Exception(
+                'Search query returned less than query_require_results; ' +
+                'consider reducing permutations or increasing ingest weight')
         return result
 
 
@@ -110,5 +130,11 @@ class AnnotationsQueryGenerator(AbstractQueryGenerator):
         url = "%s/v2.0/%s/events/getEvents?from=%d&until=%d" % (
             self.config['query_url'], tenant_id, frm, to)
         result = self.request.GET(url)
+        min_results = self.config['query_require_results']
+        payload = json.loads(result.getText())
+        if len(payload) <= min_results:
+            raise Exception(
+                'Annotations query returned less than query_require_results; ' +
+                'consider reducing permutations or increasing ingest weight')
         return result
 


### PR DESCRIPTION
While testing with various permutations, it's nice to know that queries are actually returning some data and not just succeeding with no results. At the same time, depending on your configuration, that might cause more problems than it solves, so this makes a flag to turn that behavior on or off.