### PR TITLE
increase possible metric name permutations

### DIFF
--- a/properties/grinder-local.properties
+++ b/properties/grinder-local.properties
@@ -19,12 +19,14 @@ grinder.bf.query_url="http://localhost:20000"
 
 grinder.bf.max_multiplot_metrics=10
 # Make metric names sufficiently long. Real names have lots of tokens in them.
-grinder.bf.name_fmt="org.example.metric.entity.en12345678.check.ch12345678.some_named_thing.%d"
+grinder.bf.name_fmt="org.example.metric.entity.en%d.check.en%d.some_named_thing.metric_%d"
 
 grinder.bf.ingest_weight=15
 # 100 different tenants and metrics should provide an observable amount of load in terms of number of things to ingest.
 grinder.bf.ingest_num_tenants=100
 grinder.bf.ingest_metrics_per_tenant=100
+grinder.bf.ingest_metrics_permutation_scale=100
+
 # I think metrics regularly arrive in batches of a hundred or more in production.
 grinder.bf.ingest_batch_size=200
 # A list of "delay times". When generating metrics for ingest, if the tenant id is even, one of these values will be

--- a/scripts/abstract_generator.py
+++ b/scripts/abstract_generator.py
@@ -17,6 +17,7 @@ default_config = {
     'ingest_weight': 15,
     'ingest_num_tenants': 4,
     'ingest_metrics_per_tenant': 15,
+    'ingest_metrics_permutation_scale': 15,
     'ingest_batch_size': 5,
     # ingest_delay_millis is comma separated list of delays used during
     # ingestion
@@ -65,4 +66,10 @@ class AbstractGenerator(object):
 
 
 def generate_metric_name(metric_id, config):
-    return config['name_fmt'] % metric_id
+    name_fmt = config['name_fmt']
+    dimensions = name_fmt.count('%d')
+    random_values = [random.randint(1, config['ingest_metrics_permutation_scale'])
+                     for _ in range(dimensions-1)]
+    random_values.append(metric_id)
+    format_values = tuple(random_values)
+    return name_fmt % format_values


### PR DESCRIPTION
This project was written to be able to generate metric names that were randomized in only one token of the name, which limits its usefulness in testing metric tokens at scale because all the tokens but one are the same.

In other words, even with a long name pattern like org.example.a.1.b.2.c.3.d.4.e.5.f.6.%d and your randomization factor set to 1000, you still only get 1001 tokens because all tokens leading up to the final one never change. By interspersing more randomness in that name, the number of tokens rises dramatically.

This adds the ability to do that through a new property, keeping the original behavior because tests rely on it extensively.